### PR TITLE
Added PUT /events/instances/:id, cleaned up other routes

### DIFF
--- a/server/src/api/donations/donations.router.ts
+++ b/server/src/api/donations/donations.router.ts
@@ -40,6 +40,10 @@ donationsRouter.get('/:id', async (req: Request, res: Response) => {
 donationsRouter.post('/', async (req: Request, res: Response) => {
   try {
     const newDonation = await create(req.body);
+    // TODO wrap responses
+    // eslint-disable-next-line max-len
+    // const responseData = {data: newDonation.rows, status: {success: true/false, message: "OK"/ "x rows deleted"}};
+    // same for errors as well
     res.status(201).send(newDonation.rows);
   } catch (err: any) {
     res.status(500).send(err.message);

--- a/server/src/api/events/event.service.ts
+++ b/server/src/api/events/event.service.ts
@@ -102,6 +102,12 @@ const updateEvent = async (id: string, changes: Delta[]) => {
   return queryResults;
 };
 
+const getShowingsById = async (id: string): Promise<Showing[]> => {
+  const query = `SELECT * FROM event_instances WHERE eventid = $1;`;
+  const queryResult = await pool.query(query, [id]);
+  return queryResult.rows;
+};
+
 export default {
   insertAllShowings,
   isShowingChange,
@@ -110,4 +116,5 @@ export default {
   updateEvent,
   updateShowings,
   deleteShowings,
+  getShowingsById,
 };

--- a/server/src/api/events/event.service.ts
+++ b/server/src/api/events/event.service.ts
@@ -2,7 +2,7 @@ import Delta from '../../interfaces/Delta';
 import Showing from '../../interfaces/Showing';
 import {pool} from '../db';
 
-const insertAllShowings = async (showings: Showing[]) => {
+const insertAllShowings = async (showings: Showing[]): Promise<Showing[]> => {
   const query = `
                   INSERT INTO event_instances 
                   (
@@ -13,24 +13,74 @@ const insertAllShowings = async (showings: Showing[]) => {
                     availableseats, 
                     salestatus
                   )
-                  VALUES ($1, $2, $3, $4, $4, true) RETURNING *;
+                  VALUES ($1, $2, $3, $4, $5, true) RETURNING *;
                 `;
 
   const res = [];
   for (const showing of showings) {
-    const {eventid, eventdate, starttime, totalseats, tickettype} = showing;
+    const tickettype = showing.tickettype;
     if (tickettype === undefined) {
       throw new Error('No ticket type provided');
     }
     const {rows} = await pool.query(query, [
-      eventid,
-      eventdate,
-      starttime,
-      totalseats,
+      showing.eventid,
+      showing.eventdate,
+      showing.starttime,
+      showing.totalseats,
+      showing.availableseats,
     ]);
     res.push({...rows[0], tickettype});
   }
   return res;
+};
+
+// takes in an array of Showings to be updated in DB
+const updateShowings = async (showings: Showing[]): Promise<number> => {
+  const updateQuery = `
+                        UPDATE event_instances
+                        SET
+                        eventdate = $2,
+                        starttime = $3,
+                        salestatus = $4,
+                        totalseats = $5,
+                        availableseats = $6,
+                        purchaseuri = $7
+                        WHERE id = $1
+                        `;
+  let rowsUpdated = 0;
+  for (const showing of showings) {
+    const queryResult = await pool.query(
+        updateQuery,
+        [
+          showing.id,
+          showing.eventdate,
+          showing.starttime,
+          showing.salestatus,
+          showing.totalseats,
+          showing.availableseats,
+          showing.purchaseuri,
+        ]);
+    rowsUpdated += queryResult.rowCount;
+  }
+  return rowsUpdated;
+};
+
+// takes in array of ids and deletes showings with those ids and linkedtickets
+const deleteShowings = async (ids: number[]): Promise<number> => {
+  const deleteQuery = `
+                        DELETE FROM event_instances
+                        WHERE id = $1;
+                        `;
+  let rowsDeleted = 0;
+  for (const id of ids) {
+    pool.query(
+        `DELETE FROM linkedtickets WHERE event_instance_id = $1;`,
+        [id],
+    );
+    const queryResult = await pool.query(deleteQuery, [id]);
+    rowsDeleted += queryResult.rowCount;
+  }
+  return rowsDeleted;
 };
 
 const isShowingChange = (d: Delta) => d.path.includes('showings');
@@ -52,16 +102,12 @@ const updateEvent = async (id: string, changes: Delta[]) => {
   return queryResults;
 };
 
-const propToString = (prop: any) => (obj: any) => ({
-  ...obj,
-  [prop]: obj[prop].toString(),
-});
-
 export default {
   insertAllShowings,
   isShowingChange,
   isEventChange,
   eventFields,
   updateEvent,
-  propToString,
+  updateShowings,
+  deleteShowings,
 };

--- a/server/src/interfaces/Showing.ts
+++ b/server/src/interfaces/Showing.ts
@@ -1,7 +1,11 @@
 export default interface Showing {
+    id: number;
     eventid: string;
     eventdate: string;
     starttime: string;
+    salestatus: boolean;
     totalseats: number;
+    availableseats: number;
     tickettype: number; // ticket type ID
+    purchaseuri: string;
 }


### PR DESCRIPTION
## Brief Description

Added a PUT route for /events/instances. Cleaned up GET /events and return numShows as well to reduce work in client for ManageEvents page. Cleaned up PUT /events. Updated Showing interface to match database schema (still has tickettype field that is not in the event_instances table). Removed redundant /events/list route.

## References Issue

Issue #55 

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Major change (potentially breaking, list anything that is broken below)
- [ ] Documentation

### Breaking Changes

N/A

## Testing done

Tested new endpoint as well as modified existing endpoints by making calls in Postman.


- [x] Docker was used.
- [ ] Docker was not used and I have listed my configuration below.

## Checklist:

- [x] My code follows the styling guidelines.
- [x] I have added unit tests and verified that they pass. (sort of, I added API call in Postman to test the new route)
- [x] I have used the linter and fixed any linting issues.
- [x] I have commented the code.
- [x] I have adjusted the documentation to match the changed code.
- [x] Prior to submitting the PR, I made sure the latest changes were merged with my branch.
- [x] Existing tests pass locally with changes.

### Explanation for unchecked

Provide a brief explanation for why the checklist was not completed.

## Additional information: 

Provide any additional information that might be useful for this commit.
