### PR TITLE
Removed pass_hash, added auth0_id to users table

### DIFF
--- a/server/src/api/accounts/accounts.service.ts
+++ b/server/src/api/accounts/accounts.service.ts
@@ -27,14 +27,14 @@ export const find = (id: string) => {
   return pool.query(myQuery);
 };
 
-export const create = (r: any) => {
+export const create = (r: {username: string, auth0_id: string}) => {
   const myQuery = {
     text: `
       INSERT INTO users
-      VALUES (DEFAULT, $1, $2, $3)
+      VALUES (DEFAULT, $1, DEFAULT, $2)
       RETURNING *
       `,
-    values: [r.username, r.pass_hash, r.is_superadmin],
+    values: [r.username, r.auth0_id],
   };
   return pool.query(myQuery);
 };

--- a/task_sql/wtix_dump_030422.sql
+++ b/task_sql/wtix_dump_030422.sql
@@ -474,8 +474,8 @@ CREATE TABLE public.tickettype (
 CREATE TABLE public.users (
     id integer NOT NULL,
     username character varying(255),
-    pass_hash character varying(255),
-    is_superadmin boolean DEFAULT false
+    is_superadmin boolean DEFAULT false,
+    auth0_id character varying(255)
 );
 
 
@@ -11559,12 +11559,12 @@ COPY public.tickettype (id, name, isseason, seasonid, price, concessions) FROM s
 -- Data for Name: users; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-COPY public.users (id, username, pass_hash, is_superadmin) FROM stdin;
-4	wtix	$2a$10$tRaShlhaRUDQ1ADT242dN.x2DSxstwHeHdc9hejnoV4doEbTX5Qfm	t
-0	brian		f
-1	hailey		f
-2	aiyana		f
-3	allen		f
+COPY public.users (id, username, is_superadmin) FROM stdin;
+4	wtix	t
+0	brian   f
+1	hailey  f
+2	aiyana  f
+3	allen   f
 \.
 
 

--- a/task_sql/wtix_dump_030422.sql
+++ b/task_sql/wtix_dump_030422.sql
@@ -11559,13 +11559,13 @@ COPY public.tickettype (id, name, isseason, seasonid, price, concessions) FROM s
 -- Data for Name: users; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-COPY public.users (id, username, is_superadmin) FROM stdin;
-4	wtix	t
-0	brian   f
-1	hailey  f
-2	aiyana  f
-3	allen   f
-\.
+-- COPY public.users (id, username, is_superadmin) FROM stdin;
+-- 4	wtix	    t
+-- 0	brian       f
+-- 1	hailey      f
+-- 2	aiyana      f
+-- 3	allen       f
+-- \.
 
 
 --


### PR DESCRIPTION
## Brief Description

Minor changes to users table. I removed the pass_hash column and added a auth0_id column to the users table. I also added action to Auth0, so this information is posted to API when users create accounts.

## References Issue

Issue #70

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Major change (potentially breaking, list anything that is broken below)
- [ ] Documentation

### Breaking Changes

Creating accounts in ManageAccounts page is now going to be broken. That needs to be updated to utilize Auth0 to create accounts instead. 

## Testing done

Describe tests that were used, along with instructions for testing.

- [x] Accounts Router tests

- [x] Docker was used.
- [ ] Docker was not used and I have listed my configuration below.

**System Specifications**:
* Operating System:
* Node Version:
* NPM Version:

## Checklist:

- [x] My code follows the styling guidelines.
- [x] I have added unit tests and verified that they pass.
- [x] I have used the linter and fixed any linting issues.
- [x] I have commented the code.
- [x] I have adjusted the documentation to match the changed code.
- [x] Prior to submitting the PR, I made sure the latest changes were merged with my branch.
- [x] Existing tests pass locally with changes.

### Explanation for unchecked

Provide a brief explanation for why the checklist was not completed.

## Additional information: 

Provide any additional information that might be useful for this commit.
