### PR TITLE
Modified getValidTicketTypes query so that the Pay What You Can ticket type is not returned

### DIFF
--- a/server/src/api/tickets/ticket.service.ts
+++ b/server/src/api/tickets/ticket.service.ts
@@ -91,6 +91,8 @@ const reduceToTicketState = (res: any, t: Ticket) => {
 
 //
 export const getValidTicketTypes = async (): Promise<response> => {
+  // The tickettype indexed by a tickettypeid value of 0 is reserved for 
+  // the Pay What You Can tickettype and should not be modified
   const myQuery = {
     text: `
       SELECT 
@@ -101,7 +103,7 @@ export const getValidTicketTypes = async (): Promise<response> => {
       FROM 
         tickettype 
       WHERE 
-        deprecated = false
+        deprecated = false AND tickettypeid != 0
       ORDER BY
         tickettypeid ASC;`,
   };


### PR DESCRIPTION
## Brief Description

Modified getValidTicketTypes query so that the Pay What You Can ticket type is not returned. Calls to the route `api/tickets/types` will not return the Pay What You Can ticket type to the client anymore so that it is not displayed in the Manage Ticket Types page. This is so that it will not get accidently deleted which would have breaking consequences.  

## References Issue

Issue #

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Major change (potentially breaking, list anything that is broken below)
- [ ] Documentation

### Breaking Changes

none

## Testing done

Verified result with Postman and calls from the client

...

- [x] Docker was used.
- [ ] Docker was not used and I have listed my configuration below.

**System Specifications**:
* Operating System: win10
* Node Version:
* NPM Version:

## Checklist:

- [x] My code follows the styling guidelines.
- [ ] I have added unit tests and verified that they pass.
- [ ] I have used the linter and fixed any linting issues.
- [x] I have commented the code.
- [ ] I have adjusted the documentation to match the changed code.
- [x] Prior to submitting the PR, I made sure the latest changes were merged with my branch.
- [x] Existing tests pass locally with changes.

## Additional information: 

none
