### PR TITLE
Centered "Delete Event" popup in Showings page and changed "X" button behavior in Add Event page

### DIFF
--- a/client/src/components/Ticketing/Pop-up.tsx
+++ b/client/src/components/Ticketing/Pop-up.tsx
@@ -37,7 +37,7 @@ const box: CSSProperties ={
  * @returns {ReactElement} PopUp - Function named PopUp that can be interacted
  * with
  */
-const PopUp = ({title, message, handleClose}: popupProps) => {
+const PopUp = ({title, message, handleClose, handleProceed}: popupProps) => {
   return (
     <div style={popUpContainer}>
       <div id="popup-modal"
@@ -69,10 +69,10 @@ const PopUp = ({title, message, handleClose}: popupProps) => {
                 {message}
               </p>
               <button data-modal-toggle="popup-modal"
-                onClick={handleClose}
-                type="button" className="text-white bg-red-600
-                hover:bg-red-800 focus:ring-4 focus:outline-none
-                focus:ring-red-300 dark:focus:ring-red-800 font-medium
+                onClick={handleProceed}
+                type="button" className="text-white bg-green-600
+                hover:bg-green-800 focus:ring-4 focus:outline-none
+                focus:ring-green-300 dark:focus:ring-green-800 font-medium
                  rounded-lg text-sm inline-flex items-center
                   px-5 py-2.5 text-center mr-2">
                     Proceed

--- a/client/src/components/Ticketing/ticketingmanager/Events/Add_event/CreateEventPage.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/Add_event/CreateEventPage.tsx
@@ -81,6 +81,10 @@ const CreateEventPage = () => {
 
   const handleClose = () => {
     setVisible(false);
+  };
+
+  const handleProceed = () => {
+    setVisible(false);
     nav('/ticketing/manageevent');
   };
 
@@ -89,7 +93,7 @@ const CreateEventPage = () => {
       <div className='md:ml-[18rem] md:mr-[5rem] sm:mt-40 sm:mt-[11rem]
        sm:mr-[2rem] sm:ml-[2rem] sm:mb-[11rem]'>
         {visible == true ?
-        <PopUp message='New event has been successfully added.' title="Success" handleClose={handleClose} /> :
+        <PopUp title="Success" message='New event has been successfully added.' handleClose={handleClose} handleProceed={handleProceed} /> :
          <></> }
         <h1 className='font-bold text-5xl mb-14 bg-clip-text text-transparent
          bg-gradient-to-r from-violet-500 to-fuchsia-500' >Add New Event</h1>

--- a/client/src/components/Ticketing/ticketingmanager/Events/Add_event/CreateEventPage.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/Add_event/CreateEventPage.tsx
@@ -75,7 +75,6 @@ const CreateEventPage = () => {
       // update Redux state with new event & available tickets
       if (postShowings.ok) {
         setVisible(true);
-        // nav('/ticketing/manageevent');
       }
     } else {
       console.error('New event creation failed', createPlayRes.statusText);

--- a/client/src/components/Ticketing/ticketingmanager/Events/Add_event/CreateEventPage.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/Add_event/CreateEventPage.tsx
@@ -13,6 +13,9 @@ import EventForm, {NewEventData} from '../EventForm';
 import {useAuth0} from '@auth0/auth0-react';
 import {useNavigate} from 'react-router-dom';
 import PopUp from '../../../Pop-up';
+
+let id = 0;
+
 const formatShowingData = (eventid: number) => (data: any) => {
   const {starttime, eventdate, totalseats, ticketTypeId, seatsForType} = data;
   return {eventid, eventdate, starttime, totalseats, ticketTypeId: ticketTypeId, seatsForType};
@@ -58,7 +61,7 @@ const CreateEventPage = () => {
 
     if (createPlayRes.ok) {
       const eventData = await createPlayRes.json();
-      const id = eventData.data[0].eventid;
+      id = eventData.data[0].eventid;
       const showingdata = showings.map(formatShowingData(id));
       const postShowings = await fetch(process.env.REACT_APP_ROOT_URL + '/api/events/instances', {
         credentials: 'include',
@@ -81,6 +84,7 @@ const CreateEventPage = () => {
 
   const handleClose = () => {
     setVisible(false);
+    nav(`/ticketing/editevent/${id}`);
   };
 
   const handleProceed = () => {

--- a/client/src/components/Ticketing/ticketingmanager/showings/showing/showing.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/showings/showing/showing.tsx
@@ -157,7 +157,7 @@ const Showing = () => {
         </div>
       </div>
 
-      <div className={!show ? 'hidden': 'fixed w-full h-screen overflow-x-hidden z-10'} aria-labelledby="modal-title" role="dialog" aria-modal="true">
+      <div className={!show ? 'hidden': 'fixed w-full h-screen overflow-x-hidden z-10 bg-gray-500 bg-opacity-75 transition-opacity'} aria-labelledby="modal-title" role="dialog" aria-modal="true">
         <div className="fixed z-10 inset-0 overflow-y-auto">
           <div className="flex items-end sm:items-center justify-center min-h-full p-4 text-center sm:p-0">
             <div className="relative bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full">

--- a/client/src/components/Ticketing/ticketingmanager/showings/showing/showing.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/showings/showing/showing.tsx
@@ -154,45 +154,42 @@ const Showing = () => {
             <button className='px-6 py-2 bg-blue-500 text-white rounded-xl hover:bg-blue-600 ' onClick={() => onEditClick(eventid)}>Edit Event</button>
             <button className='px-6 py-2 bg-red-500 text-white rounded-xl hover:bg-red-600 ' onClick={() => onDeleteClick(eventid)}>Delete Event</button>
           </div>
-          <div className={!show ? 'hidden': 'relative w-full h-screen overflow-x-hidden z-10'} aria-labelledby="modal-title" role="dialog" aria-modal="true">
-            <div className="fixed z-10 inset-0 overflow-y-auto">
-              <div className="flex items-end sm:items-center justify-center min-h-full p-4 text-center sm:p-0">
-                <div className="relative bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full">
-                  <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-                    <div className="sm:flex sm:items-start">
-                      <div className="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
-                        <svg className="h-6 w-6 text-red-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" aria-hidden="true">
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                        </svg>
-                      </div>
-                      <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-                        <h3 className="text-lg leading-6 font-medium text-gray-900" id="modal-title">Delete </h3>
-                        <div className="mt-2">
-                          <p className="text-sm text-gray-500">Are you sure you want to delete this?</p>
-                        </div>
-                      </div>
-                    </div>
+        </div>
+      </div>
+
+      <div className={!show ? 'hidden': 'fixed w-full h-screen overflow-x-hidden z-10'} aria-labelledby="modal-title" role="dialog" aria-modal="true">
+        <div className="fixed z-10 inset-0 overflow-y-auto">
+          <div className="flex items-end sm:items-center justify-center min-h-full p-4 text-center sm:p-0">
+            <div className="relative bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full">
+              <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                <div className="sm:flex sm:items-start">
+                  <div className="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+                    <svg className="h-6 w-6 text-red-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" aria-hidden="true">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                    </svg>
                   </div>
-                  <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-                    <button onClick={() => deleteEvent()} type="button" className="w-full inline-flex justify-center rounded-md border border-transparent
-                   shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700
-                    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500
-                     sm:ml-3 sm:w-auto sm:text-sm">Yes</button>
-                    <button onClick={onCancelDelete} type="button" className="mt-3 w-full inline-flex
-                   justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base
-                    font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2
-                     focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">Cancel</button>
+                  <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                    <h3 className="text-lg leading-6 font-medium text-gray-900" id="modal-title">Delete </h3>
+                    <div className="mt-2">
+                      <p className="text-sm text-gray-500">Are you sure you want to delete this?</p>
+                    </div>
                   </div>
                 </div>
               </div>
+              <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+                <button onClick={() => deleteEvent()} type="button" className="w-full inline-flex justify-center rounded-md border border-transparent
+                shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700
+                focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500
+                  sm:ml-3 sm:w-auto sm:text-sm">Yes</button>
+                <button onClick={onCancelDelete} type="button" className="mt-3 w-full inline-flex
+                justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base
+                font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2
+                  focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">Cancel</button>
+              </div>
             </div>
           </div>
-
         </div>
-
-
       </div>
-
 
     </div>
   );

--- a/client/src/interfaces/popup.interface.ts
+++ b/client/src/interfaces/popup.interface.ts
@@ -8,7 +8,8 @@
 {
     title: string;
     message: string;
-    handleClose:( event: any) => void;
+    handleClose: (event: any) => void;
+    handleProceed: (event: any) => void;
 }
 
 export default popupProps;


### PR DESCRIPTION
## Brief Description

Issue #152 
When the "Delete Event" button is pressed in the View Showing page, the modal shows up but the user has to scroll to the top of the page to see it. Fixed the issue so that it shows up in the center of the user's screen. Also dimmed the background when the modal pops up so that it's obvious that the user must interact with it.

Issue #146 
In the "Add Event" page, after clicking the "Save" button, a modal pops up indicating it was successfully saved. Both the "Proceed" and "X" button redirect the user to the "Manage Events" page. Fixed the issue by changing the "X" button behavior - it now closes the modal and redirects the user to the "Edit Event" page of the newly added event. Also changed the color of the "Proceed" button from red to green, so it makes more sense.

## References Issue

Issue #152 
Issue #146

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Major change (potentially breaking, list anything that is broken below)
- [ ] Documentation

### Breaking Changes

N/A

## Testing done

Tested locally.

- [x] Docker was used.
- [ ] Docker was not used and I have listed my configuration below.

**System Specifications**:
* Operating System: MacOS
* Node Version: 16.17.1
* NPM Version: 8.15.0

## Checklist:

- [x] My code follows the styling guidelines.
- [ ] I have added unit tests and verified that they pass.
- [x] I have used the linter and fixed any linting issues.
- [ ] I have commented the code.
- [ ] I have adjusted the documentation to match the changed code.
- [ ] Prior to submitting the PR, I made sure the latest changes were merged with my branch.
- [ ] Existing tests pass locally with changes.

### Explanation for unchecked

Unit testing and documentation unavailable/not discussed.

## Additional information: 

N/A
