### PR TITLE
WIP: Add event without clicking save show

### DIFF
--- a/client/src/components/CRM/Accounts/ManageUsers/ManageAccounts.tsx
+++ b/client/src/components/CRM/Accounts/ManageUsers/ManageAccounts.tsx
@@ -180,7 +180,8 @@ export default function ManageAccounts() {
               onCellEditCommit={editCommit}
               autoHeight
               style={{width: '100%'}}
-              pageSize={10} />
+              pageSize={10}
+              getRowId={(row) => row.userid}/>
           </div>
           <div className='mt-7 ml-2 text-xl font-bold mb-2 text-zinc-700 '>
             Create New Account

--- a/client/src/components/Ticketing/ticketingmanager/Events/Edit_event/EditEventPage.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/Edit_event/EditEventPage.tsx
@@ -53,14 +53,6 @@ const EditEventPage = ({initValues}: mapDataToEditEventProps) => {
   };
 
   const onSubmit = async (updatedData: NewEventData) => {
-    const dataToSave = {
-      id: params.eventid,
-      eventname: updatedData.eventName,
-      eventdescription: updatedData.eventDesc,
-      active: updatedData.isPublished,
-      image_url: updatedData.imageUrl,
-      seasonid: updatedData.seasonID,
-    };
     const token = await getAccessTokenSilently({
       audience: 'https://localhost:8000',
       scope: 'admin',
@@ -72,7 +64,7 @@ const EditEventPage = ({initValues}: mapDataToEditEventProps) => {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${token}`,
       },
-      body: JSON.stringify(dataToSave),
+      body: JSON.stringify(updatedData),
     });
 
     await fetch(process.env.REACT_APP_ROOT_URL + `/api/events/instances/${params.eventid}`, {

--- a/client/src/components/Ticketing/ticketingmanager/Events/EventForm.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/EventForm.tsx
@@ -149,10 +149,6 @@ const EventForm = ({onSubmit, ticketTypes, initialValues}: EventFormProps) => {
 
   // Handle new play and the show options
   const handleSubmit = () => {
-    // if (showings === undefined || showings.length == 0) {
-    //   console.log('ERROR: NO SHOWINGS!');
-    //   return;
-    // }
     const data: NewEventData = {
       eventName,
       eventID,

--- a/client/src/components/Ticketing/ticketingmanager/Events/EventForm.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/EventForm.tsx
@@ -157,8 +157,8 @@ const EventForm = ({onSubmit, ticketTypes, initialValues}: EventFormProps) => {
       imageUrl,
       showings: showings,
     };
-    console.log(data);
-    onSubmit(data);
+    if (eventName === '' || eventDesc === '') alert("You must enter an event name and an even description");
+    else onSubmit(data);
   };
 
   return (

--- a/client/src/components/Ticketing/ticketingmanager/Events/EventForm.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/EventForm.tsx
@@ -157,7 +157,7 @@ const EventForm = ({onSubmit, ticketTypes, initialValues}: EventFormProps) => {
       imageUrl,
       showings: showings,
     };
-    if (eventName === '' || eventDesc === '') alert("You must enter an event name and an even description");
+    if (eventName === '' || eventDesc === '') alert('You must enter an event name and an even description');
     else onSubmit(data);
   };
 

--- a/client/src/components/Ticketing/ticketingmanager/Events/EventForm.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/EventForm.tsx
@@ -143,60 +143,27 @@ const EventForm = ({onSubmit, ticketTypes, initialValues}: EventFormProps) => {
     setImageURL(url.target.value);
   }, [imageUrl]);
 
-  // Callback to get new show from child component to the parent
-  const addShowData = useCallback((show) => {
-    const isInShowList = showings.some((element) => element.id === show.id);
-    if (isInShowList) {
-      const newShowList = showings.filter(((element) => element.id !== show.id));
-      const index = showings.findIndex((i) => {
-        return i.eventdate === show.eventdate && i.starttime === show.starttime;
-      });
-      if (index > -1) {
-        showings[index] = show;
-      } else {
-        newShowList.push(show);
-        setShowings((showings) => [...showings, ...newShowList]);
-      }
-    } else {
-      showings.push(show);
-    }
-    console.log(showings);
-  }, [showings]);
-
-  const deleteShowing = useCallback((event) => {
-    const div = event.target.parentElement;
-    const inputs = div.querySelectorAll('input');
-    const length = inputs.length;
-    const date = inputs[length - 2].value;
-    const time = inputs[length - 1].value;
-    const index = showings.findIndex((el) => {
-      return el.eventdate === date && el.starttime === time;
-    });
-    if (index > -1) {
-      showings.splice(index, 1);
-      console.log(showings);
-    }
-  }, [showings]);
-
-  const updateShows = useCallback((shows: Showing[]) => {
+  const setShowingsHandler = (shows) => {
     setShowings(shows);
-  }, [showings]);
+  };
 
   // Handle new play and the show options
   const handleSubmit = () => {
+    // if (showings === undefined || showings.length == 0) {
+    //   console.log('ERROR: NO SHOWINGS!');
+    //   return;
+    // }
     const data: NewEventData = {
       eventName,
       eventID,
       eventDesc,
       isPublished,
       imageUrl,
-      showings,
+      showings: showings,
     };
     console.log(data);
     onSubmit(data);
   };
-
-  console.log(def);
 
   return (
     <Form
@@ -243,7 +210,7 @@ const EventForm = ({onSubmit, ticketTypes, initialValues}: EventFormProps) => {
             <div>
               {/*  Button to trigger add of new show*/}
               <div id="show-table">
-                <ShowListController showsData={def.showings.length != 0 ? def.showings: []} addShowData = {addShowData} deleteShowing={deleteShowing} eventid={def.eventID}/>
+                <ShowListController showsData={def.showings.length != 0 ? def.showings: []} eventid={def.eventID} setShowingsHandler={setShowingsHandler}/>
               </div>
             </div>
           </div>

--- a/client/src/components/Ticketing/ticketingmanager/Events/EventForm.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/EventForm.tsx
@@ -15,6 +15,7 @@ import React, {useCallback, useState} from 'react';
 import InputFieldForEvent from './InputField';
 import ShowListController from '../Events/showListController';
 import {Showing} from '../../../../interfaces/showing.interface';
+import PopUp from '../../Pop-up';
 
 /**
  * Type of ticket
@@ -128,6 +129,8 @@ const EventForm = ({onSubmit, ticketTypes, initialValues}: EventFormProps) => {
   const [imageUrl, setImageURL] = useState(def.imageUrl);
   const isPublished = def.isPublished;
   const [showings, setShowings] = useState(def.showings);
+  const [showPopUp, setShowPopUp] = useState(false);
+  const [err, setErr] = useState('');
 
   // FIELDS CALLBACK
   // Set event name
@@ -157,69 +160,122 @@ const EventForm = ({onSubmit, ticketTypes, initialValues}: EventFormProps) => {
       imageUrl,
       showings: showings,
     };
-    if (eventName === '' || eventDesc === '' || showings.length === 0) alert('You must enter an event name, an event description, and insert at least one showing');
-    else onSubmit(data);
+    console.log(data);
+    if (showings.length === 0) {
+      setErr('Please enter at least one showing.');
+      setShowPopUp(true);
+      return;
+    }
+    if (eventName === '' || eventDesc === '' || showings.length === 0) {
+      const conditions = [];
+      if (eventName === '') {
+        conditions.push('Event name');
+      }
+      if (eventDesc === '') {
+        conditions.push('Event description');
+      }
+      let message = '';
+      if (conditions.length > 0) {
+        message += conditions.slice(0, -1).join(', ');
+        if (conditions.length > 1) {
+          message += ' and ';
+        }
+        message += conditions[conditions.length - 1];
+      }
+      if (conditions.length === 1) {
+        message += ' field is missing.';
+      } else {
+        message += ' fields are missing.';
+      }
+      setErr(message);
+      setShowPopUp(true);
+      return;
+    }
+    for (let i = 0; i < data.showings.length; i++) {
+      if (data.showings[i].eventdate === '' || data.showings[i].starttime === '') {
+        setErr('Each showing must have an event date and an event time.');
+        setShowPopUp(true);
+        return;
+      }
+      if (data.showings[i].totalseats < 1) {
+        setErr('Each showing must have at least 1 ticket.');
+        setShowPopUp(true);
+        return;
+      }
+    }
+    for (let i = 0; i < data.showings.length; i++) {
+      for (let j = data.showings[i].ticketTypeId.length - 1; j >= 0; j--) {
+        if (data.showings[i].ticketTypeId[j] === 'NaN') {
+          data.showings[i].seatsForType.splice(j, 1);
+          data.showings[i].ticketTypeId.splice(j, 1);
+        }
+      }
+    }
+    onSubmit(data);
   };
 
   return (
-    <Form
-      onSubmit={handleSubmit}
-      initialValues={initialValues ?? initialState}
-      mutators={{...arrayMutators}}
-      validate={validate}
-      render={({
-        handleSubmit,
-      }) => (
-        <form onSubmit={handleSubmit}>
-          <div className='bg-white flex flex-col  p-6 rounded-xl shadow-xl'>
-            <div className='text-3xl font-semibold mb-5'>
-                Event Information
-            </div>
-            <div className='w-full flex flex-col '>
-              <InputFieldForEvent
-                name={'eventName'}
-                id={'eventName'} headerText={'Enter Event Name'}
-                action={addEventName} actionType={'onChange'} value={def.eventName}
-                placeholder={def.eventName ? def.eventName: 'Event Name'} />
+    <div>
+      {showPopUp ? <PopUp message={err} title='Failed to save.' handleClose={() => setShowPopUp(false)}/> : null}
+      <Form
+        onSubmit={handleSubmit}
+        initialValues={initialValues ?? initialState}
+        mutators={{...arrayMutators}}
+        validate={validate}
+        render={({
+          handleSubmit,
+        }) => (
+          <form onSubmit={handleSubmit}>
+            <div className='bg-white flex flex-col  p-6 rounded-xl shadow-xl'>
+              <div className='text-3xl font-semibold mb-5'>
+                  Event Information
+              </div>
+              <div className='w-full flex flex-col '>
+                <InputFieldForEvent
+                  name={'eventName'}
+                  id={'eventName'} headerText={'Enter Event Name'}
+                  action={addEventName} actionType={'onChange'} value={def.eventName}
+                  placeholder={def.eventName ? def.eventName: 'Event Name'} />
 
-              <InputFieldForEvent
-                name={'eventDesc'}
-                id={'eventDesc'} headerText={'Enter Short Event Description'}
-                actionType={'onChange'}
-                action={addEventDesc} value={def.eventDesc}
-                placeholder={def.eventDesc ? def.eventDesc : 'Event Description'} />
+                <InputFieldForEvent
+                  name={'eventDesc'}
+                  id={'eventDesc'} headerText={'Enter Short Event Description'}
+                  actionType={'onChange'}
+                  action={addEventDesc} value={def.eventDesc}
+                  placeholder={def.eventDesc ? def.eventDesc : 'Event Description'} />
 
-              <InputFieldForEvent
-                name={'imageUrl'}
-                id={'imageUrl'} headerText={'Upload Image for Event'}
-                action={addURL} actionType={'onChange'} value={def.imageUrl}
-                placeholder={def.imageUrl ? def.imageUrl : 'image URL'}/>
-            </div>
-            {/* Showings container*/}
-            <div className='text-3xl font-semibold mt-5'>
-                Showings
-            </div>
-            <div className='mb-3 text-sm text-zinc-600'>
-                You can configure occurances of this event below.
-                To add more, click the &quot;Add Showing&quot; button.
-            </div>
-            <div>
-              {/*  Button to trigger add of new show*/}
-              <div id="show-table">
-                <ShowListController showsData={def.showings.length != 0 ? def.showings: []} eventid={def.eventID} setShowingsHandler={setShowingsHandler}/>
+                <InputFieldForEvent
+                  name={'imageUrl'}
+                  id={'imageUrl'} headerText={'Upload Image for Event'}
+                  action={addURL} actionType={'onChange'} value={def.imageUrl}
+                  placeholder={def.imageUrl ? def.imageUrl : 'image URL'}/>
+              </div>
+              {/* Showings container*/}
+              <div className='text-3xl font-semibold mt-5'>
+                  Showings
+              </div>
+              <div className='mb-3 text-sm text-zinc-600'>
+                  You can configure occurances of this event below.
+                  To add more, click the &quot;Add Showing&quot; button.
+              </div>
+              <div>
+                {/*  Button to trigger add of new show*/}
+                <div id="show-table">
+                  <ShowListController showsData={def.showings.length != 0 ? def.showings: []} eventid={def.eventID} setShowingsHandler={setShowingsHandler}/>
+                </div>
               </div>
             </div>
-          </div>
 
-          <button
-            className='px-3 py-2 bg-blue-600 text-white rounded-xl mt-5'
-            type='submit'
-          >
-            Save
-          </button>
-        </form>
-      )}
-    />
+            <button
+              className='px-3 py-2 bg-blue-600 text-white rounded-xl mt-5'
+              type='submit'
+            >
+              Save
+            </button>
+          </form>
+        )}
+      />
+    </div>
   );
 };
 

--- a/client/src/components/Ticketing/ticketingmanager/Events/EventForm.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/EventForm.tsx
@@ -157,7 +157,7 @@ const EventForm = ({onSubmit, ticketTypes, initialValues}: EventFormProps) => {
       imageUrl,
       showings: showings,
     };
-    if (eventName === '' || eventDesc === '') alert('You must enter an event name and an even description');
+    if (eventName === '' || eventDesc === '' || showings.length === 0) alert('You must enter an event name, an event description, and insert at least one showing');
     else onSubmit(data);
   };
 

--- a/client/src/components/Ticketing/ticketingmanager/Events/ManageEvents.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/ManageEvents.tsx
@@ -106,7 +106,7 @@ export default function ManageEventsPage({data}: any): ReactElement {
         <h1 className='font-bold text-5xl mb-14 bg-clip-text text-transparent
        bg-gradient-to-r from-cyan-500 to-blue-500   '>Manage Events</h1>
         <div className='bg-white p-3 rounded-xl mb-4 shadow-lg'>
-          <DataGrid className='bg-white' autoHeight columns={columns} rows={data} pageSize={10} />
+          <DataGrid className='bg-white' autoHeight columns={columns} rows={data} pageSize={10} rowsPerPageOptions={[10]} />
         </div>
         <button
           className='px-3 py-2 bg-green-500 text-white rounded-xl hover:bg-green-700'

--- a/client/src/components/Ticketing/ticketingmanager/Events/deleteConfirm.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/deleteConfirm.tsx
@@ -1,0 +1,102 @@
+/* eslint-disable max-len */
+import React, {CSSProperties} from 'react';
+import popupProps from '../../../../interfaces/popup.interface';
+
+/**
+ * @property {object} popUpContainer - A property container for pop up
+ */
+const popUpContainer: CSSProperties = {
+  'position': 'fixed',
+  'background': '#00000050',
+  'width': '100%',
+  'height': '100vh',
+  'top': '0',
+  'left': '0',
+};
+
+/**
+ * @property {object} box - A property container for the box used for pop up
+ */
+const box: CSSProperties ={
+  'position': 'relative',
+  'width': '50%',
+  'margin': '0 auto',
+  'alignContent': 'center',
+  'height': 'auto',
+  'maxHeight': '70vh',
+  'marginTop': 'calc(100vh - 60vh - 20px)',
+  'overflow': 'auto',
+  'marginLeft': '30%',
+};
+
+interface DeleteConfirmProps {
+  message: string;
+  setShowConfirm;
+  handleDelete;
+  id;
+}
+/**
+ * Popup makes use of both popUpContainer and box for styles
+ *
+ * @module
+ * @param {string} message - Message of popup
+ * @returns {ReactElement} PopUp - Function named PopUp that can be interacted
+ * with
+ */
+
+const DeleteConfirm = ({message, setShowConfirm, handleDelete, id}: DeleteConfirmProps) => {
+  const handleClose = (e) => {
+    if (e.target.value === 'Yes') {
+      handleDelete(e);
+    }
+    setShowConfirm(false);
+  };
+
+  return (
+    <div style={popUpContainer}>
+      <div id="popup-modal"
+        tabIndex={-1}
+        style={box} className="overflow-y-auto
+        text-center
+         overflow-x-hidden fixed top-0 right-0
+         left-0 z-50 md:inset-0 h-modal md:h-full">
+        <div
+          style={{marginLeft: 'auto', marginRight: 'auto'}}
+          className="relative p-4 w-full max-w-md h-full md:h-auto">
+          <div className="relative bg-white
+          rounded-lg shadow dark:bg-white-700">
+            <div className="p-6 text-center">
+              <p className="mb-5 text-lg font-normal
+               text-black-500 dark:text-black-400">
+                {message}
+              </p>
+              <button data-modal-toggle="popup-modal"
+                onClick={handleClose}
+                id={id}
+                type="button" className="text-white bg-gray-600
+                hover:bg-gray-800 focus:ring-4 focus:outline-none
+                focus:ring-gray-300 dark:focus:ring-gray-800 font-medium
+                 rounded-lg text-sm inline-flex items-center
+                  px-5 py-2.5 text-center mr-2" value="No">
+                    Return
+              </button>
+              <button data-modal-toggle="popup-modal"
+                id={id}
+                onClick={handleClose}
+                type="button" className="text-white bg-red-600
+                hover:bg-red-800 focus:ring-4 focus:outline-none
+                focus:ring-red-300 dark:focus:ring-red-800 font-medium
+                 rounded-lg text-sm inline-flex items-center
+                  px-5 py-2.5 text-center mr-2" value="Yes">
+                    Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  );
+};
+
+export default DeleteConfirm;

--- a/client/src/components/Ticketing/ticketingmanager/Events/showListController.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/showListController.tsx
@@ -55,8 +55,6 @@ const ShowListController = ({showsData, eventid, setShowingsHandler}: ShowListCo
 
   const handleSetShow = useCallback((show) => {
     const showItems = [...shows];
-    let showToModify = showItems[show.id];
-    showToModify = show;
     showItems[show.id] = show;
     setShow(showItems);
     setShowingsHandler(showItems);

--- a/client/src/components/Ticketing/ticketingmanager/Events/showListController.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/showListController.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable require-jsdoc */
 /* eslint-disable max-len */
-import React, {useState, useCallback} from 'react';
+import React, {useState, useCallback, useEffect} from 'react';
 import {Showing} from '../../../../interfaces/showing.interface';
 // import EventForm from './EventForm';
 import ShowingInputContainer from './showingInputContainer';
@@ -28,19 +28,15 @@ interface ShowListControllerProps{
  * @returns {ReactElement} and {ShowingInputContainer}
  */
 const ShowListController = ({showsData, eventid, setShowingsHandler}: ShowListControllerProps) => {
-  const [shows, setShow] = useState(showsData ? showsData: []);
-  let showingNum = 0;
+  const [shows, setShow] = useState(showsData ? showsData : []);
+  const [numOfShowings, setNumoOfShowings] = useState(showsData ? showsData.length : 0);
+
   // SHOWINGS ACTIONS:
   const addShowBox = (event) => {
     event.preventDefault();
-    let id = 0;
-    if (shows.length > 0) {
-      id = shows[shows.length - 1].id + 1;
-    } else {
-      id = 0;
-    }
+    setNumoOfShowings(numOfShowings + 1);
     const show: Showing = {
-      id: id,
+      id: numOfShowings,
       eventid: eventid,
       starttime: '',
       eventdate: '',
@@ -57,19 +53,34 @@ const ShowListController = ({showsData, eventid, setShowingsHandler}: ShowListCo
     const showItems = [...shows];
     showItems[show.id] = show;
     setShow(showItems);
-    setShowingsHandler(showItems);
   }, [shows]);
+
+  const handleDeleteShow = useCallback((e) => {
+    const newShowItems = shows.filter((_, i) => i !== parseInt(e.target.id));
+    newShowItems.forEach((e, i) => {
+      e.id = i;
+    });
+    console.log(newShowItems);
+    setNumoOfShowings(numOfShowings - 1);
+    setShow(newShowItems);
+  }, [shows]);
+
+
+  useEffect(() => {
+    console.log(shows);
+    setShowingsHandler(shows);
+  }, [handleSetShow, handleDeleteShow]);
 
   return (
     <>
       {shows.map((element, index) => {
         return (
           <ShowingInputContainer
-            initialData={element}
-            id={element.id}
-            showingNum={showingNum += 1}
-            key={index}
+            showingData={element}
+            id={element.id ? element.id : index}
+            key={element.id ? element.id : index}
             handleSetShow={handleSetShow}
+            handleDeleteShow={handleDeleteShow}
           />);
       })}
       <div>

--- a/client/src/components/Ticketing/ticketingmanager/Events/showListController.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/showListController.tsx
@@ -29,12 +29,12 @@ interface ShowListControllerProps{
  */
 const ShowListController = ({showsData, eventid, setShowingsHandler}: ShowListControllerProps) => {
   const [shows, setShow] = useState(showsData ? showsData : []);
-  const [numOfShowings, setNumoOfShowings] = useState(showsData ? showsData.length : 0);
+  const [numOfShowings, setNumOfShowings] = useState(showsData ? showsData.length : 0);
 
   // SHOWINGS ACTIONS:
   const addShowBox = (event) => {
     event.preventDefault();
-    setNumoOfShowings(numOfShowings + 1);
+    setNumOfShowings(numOfShowings + 1);
     const show: Showing = {
       id: numOfShowings,
       eventid: eventid,
@@ -49,25 +49,24 @@ const ShowListController = ({showsData, eventid, setShowingsHandler}: ShowListCo
     setShow((shows) => [...shows, show]);
   };
 
-  const handleSetShow = useCallback((show) => {
+  const handleSetShow = (show) => {
     const showItems = [...shows];
     showItems[show.id] = show;
     setShow(showItems);
-  }, [shows]);
+  };
 
-  const handleDeleteShow = useCallback((e) => {
+  const handleDeleteShow = (e) => {
     const newShowItems = shows.filter((_, i) => i !== parseInt(e.target.id));
     newShowItems.forEach((e, i) => {
       e.id = i;
     });
     console.log(newShowItems);
-    setNumoOfShowings(numOfShowings - 1);
+    setNumOfShowings(numOfShowings - 1);
     setShow(newShowItems);
-  }, [shows]);
+  };
 
 
   useEffect(() => {
-    console.log(shows);
     setShowingsHandler(shows);
   }, [handleSetShow, handleDeleteShow]);
 

--- a/client/src/components/Ticketing/ticketingmanager/Events/showListController.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/showListController.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable require-jsdoc */
 /* eslint-disable max-len */
-import React, {useState} from 'react';
+import React, {useState, useCallback} from 'react';
 import {Showing} from '../../../../interfaces/showing.interface';
 // import EventForm from './EventForm';
 import ShowingInputContainer from './showingInputContainer';
@@ -10,66 +10,69 @@ import ShowingInputContainer from './showingInputContainer';
  *
  * @param {Showing[]} showsData
  * @param {Showing} show
- * @param {Function} addShowData
  * @param {Showing[]} shows
  * @param {Function} updateShows
  * @param {number} eventid
+ * @param {Function} setShowingsHandler
  */
 interface ShowListControllerProps{
    showsData?: Showing[],
-   addShowData: (show: Showing) => void,
-   deleteShowing: (event: Event) => void,
    eventid: number,
+   setShowingsHandler: (show) => void,
 }
 
 /**
  * The shows handler
  *
- * @param {ShowListControllerProps} showsData, addShowData, updateShows, eventid
+ * @param {ShowListControllerProps} showsData, updateShows, eventid, setShowingsHandler
  * @returns {ReactElement} and {ShowingInputContainer}
  */
-const ShowListController = ({showsData, addShowData, deleteShowing, eventid}: ShowListControllerProps) => {
-  const [shows, addShow] = useState(showsData ? showsData: []);
+const ShowListController = ({showsData, eventid, setShowingsHandler}: ShowListControllerProps) => {
+  const [shows, setShow] = useState(showsData ? showsData: []);
   let showingNum = 0;
   // SHOWINGS ACTIONS:
   const addShowBox = (event) => {
     event.preventDefault();
-    /* let id;
+    let id = 0;
     if (shows.length > 0) {
       id = shows[shows.length - 1].id + 1;
     } else {
       id = 0;
-    } */
+    }
     const show: Showing = {
-      id: 0,
+      id: id,
       eventid: eventid,
-      starttime: undefined,
-      eventdate: undefined,
-      salestatus: true,
+      starttime: '',
+      eventdate: '',
       ticketTypeId: [],
       seatsForType: [],
       availableseats: 0,
       totalseats: 0,
+      salestatus: true,
     };
-    addShow((shows) => [...shows, show]);
-    console.log(shows);
+    setShow((shows) => [...shows, show]);
   };
 
-  const deleteShowingBox = (event) => {
-    const toRemove = event.target.parentElement.parentElement;
-    console.log(toRemove);
-    toRemove.remove();
-    console.log(shows);
-    deleteShowing(event);
-  };
+  const handleSetShow = useCallback((show) => {
+    const showItems = [...shows];
+    let showToModify = showItems[show.id];
+    showToModify = show;
+    showItems[show.id] = show;
+    setShow(showItems);
+    setShowingsHandler(showItems);
+  }, [shows]);
 
   return (
     <>
       {shows.map((element, index) => {
-        return (<ShowingInputContainer
-          initialData={element}
-          id={element.id} showingNum={showingNum += 1} key={index}
-          addShow={addShowData} deleteShow={deleteShowingBox}/>);
+        return (
+          <ShowingInputContainer
+            initialData={element}
+            id={element.id}
+            showingNum={showingNum += 1}
+            key={index}
+            handleSetShow={handleSetShow}
+          />);
       })}
       <div>
         <button

--- a/client/src/components/Ticketing/ticketingmanager/Events/showingInputContainer.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/showingInputContainer.tsx
@@ -98,8 +98,14 @@ const ShowingInputContainer = ({showingData, id, handleSetShow, handleDeleteShow
 
   const handleSeatChange = (e) => {
     const newSeats = [...seatsForType];
-    newSeats[parseInt(e.target.id)] = parseInt(e.target.value);
-    setSeatsForType(newSeats);
+    if (parseInt(e.target.value) >= 0) {
+      newSeats[parseInt(e.target.id)] = parseInt(e.target.value);
+      setSeatsForType(newSeats);
+    }
+    else {
+      newSeats[parseInt(e.target.id)] = 0;
+      setSeatsForType(newSeats);
+    }
   };
 
   const handleRemoveOption = (e) => {

--- a/client/src/components/Ticketing/ticketingmanager/Events/showingInputContainer.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/showingInputContainer.tsx
@@ -21,14 +21,15 @@ interface InitialData {
   ispreview?: boolean,
   purchaseuri?: string,
   salestatus?: boolean,
-  totalseats?: number
+  totalseats?: number,
+  starttime?: number | string,
 }
 
 export interface MapPropsToShowingInputContainer {
-  initialData: InitialData;
+  showingData: InitialData;
   id: number;
-  showingNum: number;
   handleSetShow: (show: Showing) => void;
+  handleDeleteShow: (e: any) => void;
 }
 
 
@@ -39,23 +40,32 @@ export interface MapPropsToShowingInputContainer {
  */
 // eslint-disable-next-line react/prop-types
 
+
 const toDateStringFormat = (date) => {
+  if (date === undefined || date === '') return '';
   const dateString = String(date);
+  if (dateString.split('-').length === 3) return dateString;
   return `${dateString.slice(0, 4)}-${dateString.slice(4, 6)}-${dateString.slice(6, 8)}`;
 };
 
-const ShowingInputContainer = ({initialData, id, showingNum, handleSetShow}:MapPropsToShowingInputContainer) => {
-  const [starttime, setStartTime] = useState(initialData.eventtime !== undefined? initialData.eventtime.slice(0, 8): '');
-  const [eventdate, setEventDate] = useState(initialData.eventdate !== undefined? toDateStringFormat(initialData.eventdate) : '');
+const toTimeStringFormat = (time) => {
+  if (time === undefined || time === '') return '';
+  const timeString = String(time);
+  if (timeString.split(/[+-]/).length === 1) return timeString;
+  return timeString.split(/[+-]/)[0];
+};
+
+const ShowingInputContainer = ({showingData, id, handleSetShow, handleDeleteShow}:MapPropsToShowingInputContainer) => {
+  const [starttime, setStartTime] = useState(showingData.eventtime !== undefined ? showingData.eventtime.slice(0, 8): '');
+  const [eventdate, setEventDate] = useState(showingData.eventdate !== undefined ? toDateStringFormat(showingData.eventdate) : '');
   const [ticketTypeId, setTicketTypeId] = useState([]); // TODO: Fill this initial data out to properly load
   const [seatsForType, setSeatsForType] = useState([]); // TODO: Fill this initial data out to properly load
-  const [availableSeats, setAvailableSeats] = useState(initialData.availableseats !== undefined? initialData.availableseats: 0);
-  const [totalSeats, setTotalSeats] = useState(initialData.totalseats !== undefined? initialData.totalseats: 0);
+  const [availableSeats, setAvailableSeats] = useState(showingData.availableseats !== undefined ? showingData.availableseats : 0);
+  const [totalSeats, setTotalSeats] = useState(showingData.totalseats !== undefined ? showingData.totalseats : 0);
 
   const [ticketTypes, setTicketTypes] = useState([]);
 
 
-  const dateFieldValue = typeof eventdate === 'string' ? eventdate.split('T') : '';
   const fetchTicketTypes = async () => {
     const res = await fetch(process.env.REACT_APP_ROOT_URL + '/api/tickets/allTypes');
     const data = await res.json();
@@ -64,12 +74,12 @@ const ShowingInputContainer = ({initialData, id, showingNum, handleSetShow}:MapP
 
   useEffect(() => {
     fetchTicketTypes();
-  }, [initialData]);
+  }, [showingData]);
 
   useEffect(() => {
     const showing: Showing = {
       id: id,
-      eventid: initialData.eventid_fk,
+      eventid: showingData.eventid_fk,
       starttime: starttime,
       eventdate: eventdate,
       ticketTypeId: ticketTypeId,
@@ -80,7 +90,6 @@ const ShowingInputContainer = ({initialData, id, showingNum, handleSetShow}:MapP
     };
     handleSetShow(showing);
   }, [starttime, eventdate, ticketTypeId, totalSeats, availableSeats, seatsForType]);
-
 
   const handleAddTicketOption = (e) => {
     setSeatsForType((data) => [...data, 0]);
@@ -93,14 +102,14 @@ const ShowingInputContainer = ({initialData, id, showingNum, handleSetShow}:MapP
     setSeatsForType(newSeats);
   };
 
-  const handleRemove = (e) => {
-    const newSeats = seatsForType.filter((seat, i) => i !== parseInt(e.target.value));
-    const newTypes = ticketTypeId.filter((ticketType, i) => i !== parseInt(e.target.value));
+  const handleRemoveOption = (e) => {
+    const newSeats = seatsForType.filter((_, i) => i !== parseInt(e.target.value));
+    const newTypes = ticketTypeId.filter((_, i) => i !== parseInt(e.target.value));
     setSeatsForType(newSeats);
     setTicketTypeId(newTypes);
   };
 
-  const handleOptionChange = (e) => {
+  const handleChangeOption = (e) => {
     const newList = [...ticketTypeId];
     newList[e.target.id] = parseInt(e.target.value);
     setTicketTypeId(newList);
@@ -109,16 +118,15 @@ const ShowingInputContainer = ({initialData, id, showingNum, handleSetShow}:MapP
   return (
     <div className='bg-violet-200 rounded-xl p-10 shadow-md mb-4' key={id}>
       <div key={id} className='shadow-xl p-5 rounded-xl mb-9 bg-violet-700'>
-        <label className='font-semibold text-white mb-7 mt-7  '>Show # {id ? id : showingNum}</label>
+        <label className='font-semibold text-white mb-7 mt-7  '>Show # {id + 1}</label>
         <div className='flex flex-col gap-5 mt-5 md:pr-20'>
           <h3 className='font-semibold text-white'>Total Tickets For Showing</h3>
           <input
             className='input rounded-lg p-2 bg-violet-100 w-full md:w-7/8'
-            value={totalSeats}
-            name={`${initialData.eventdate}`}
+            value={showingData.totalseats}
             type='number'
             required
-            placeholder='# of Seats'
+            key={id}
             onChange={(ev: React.ChangeEvent<HTMLInputElement>): void => {
               if (isNaN(parseInt(ev.target.value))) setTotalSeats(0);
               if (parseInt(ev.target.value) >= 0) setTotalSeats(parseInt(ev.target.value));
@@ -127,33 +135,32 @@ const ShowingInputContainer = ({initialData, id, showingNum, handleSetShow}:MapP
           />
           <div className='w-full'>
             <div className='toAdd flex flex-col gap-5 md:pr-20 w-full' id='toAdd'></div>
-            {seatsForType.length > 0 ?
-                seatsForType.map((seats, i) => (
-                  <div key={i} className='flex flex-col gap-5 mt-2 md:pr-20 bg-violet-800 rounded-xl p-2 pt-5'>
-                    <input
-                      id={String(i)}
-                      className='input rounded-lg p-2 bg-violet-100 w-full flex flex-col'
-                      name='numInput'
-                      type='number'
-                      placeholder='# of Seats'
-                      onChange={handleSeatChange}
-                      value={seatsForType[i]}
-                    >
-                    </input>
-                    <select className='p-2 rounded-lg bg-violet-100' name='typeSelect' onChange={handleOptionChange} id={String(i)} value={ticketTypeId[i]}>
-                      <option className='text-sm text-zinc-700'>
-                        Select Ticket Type
-                      </option>
-                      {ticketTypes.map((ticketType, j) => <option key={j} className='text-sm text-zinc-700' value={ticketType.id}>
-                        {ticketType.description}: {ticketType.price} (+{ticketType.concessions} concessions)
-                      </option>)}
-                    </select>
-                    <button className='w-min block px-2 py-1 bg-red-500 disabled:opacity-30 mb-4 text-white rounded-lg text-sm'
-                      type='button' onClick={handleRemove} value={i}>
-                      Remove
-                    </button>
-                  </div>)):
-              null
+            {
+              seatsForType.map((seats, i) => (
+                <div key={i} className='flex flex-col gap-5 mt-2 md:pr-20 bg-violet-800 rounded-xl p-2 pt-5'>
+                  <input
+                    id={String(i)}
+                    className='input rounded-lg p-2 bg-violet-100 w-full flex flex-col'
+                    name='numInput'
+                    type='number'
+                    placeholder='# of Seats'
+                    onChange={handleSeatChange}
+                    value={seatsForType[i]}
+                  >
+                  </input>
+                  <select className='p-2 rounded-lg bg-violet-100' name='typeSelect' onChange={handleChangeOption} id={String(i)} value={ticketTypeId[i]}>
+                    <option className='text-sm text-zinc-700'>
+                      Select Ticket Type
+                    </option>
+                    {ticketTypes.map((ticketType, j) => <option key={j} className='text-sm text-zinc-700' value={ticketType.id}>
+                      {ticketType.description}: {ticketType.price} (+{ticketType.concessions} concessions)
+                    </option>)}
+                  </select>
+                  <button className='w-min block px-2 py-1 bg-red-500 disabled:opacity-30 mb-4 text-white rounded-lg text-sm'
+                    type='button' onClick={handleRemoveOption} value={i}>
+                    Remove
+                  </button>
+                </div>))
             }
             <button className='block px-2 py-1 bg-blue-500 disabled:opacity-30
               mt-4 mb-2 text-white rounded-lg text-sm'
@@ -164,7 +171,7 @@ const ShowingInputContainer = ({initialData, id, showingNum, handleSetShow}:MapP
             <div>
               <h3 className='font-semibold text-white'>Enter Date</h3>
               <input type="date" id="date" className='input w-full p-2 rounded-lg bg-violet-100 mb-7'
-                value={dateFieldValue[0]}
+                value={toDateStringFormat(showingData.eventdate)}
                 onChange={(ev: React.ChangeEvent<HTMLInputElement>): void => {
                   setEventDate(ev.target.value);
                 } }/>
@@ -172,7 +179,7 @@ const ShowingInputContainer = ({initialData, id, showingNum, handleSetShow}:MapP
             <div >
               <h3 className='font-semibold text-white'>Enter time</h3>
               <input type="time" id="time" name="starttime" placeholder='00:00:00'className='w-full p-2 rounded-lg bg-violet-100 mb-7 '
-                value={starttime}
+                value={toTimeStringFormat(showingData.eventtime ? showingData.eventtime : showingData.starttime)}
                 onChange={(ev: React.ChangeEvent<HTMLInputElement>): void =>{
                   setStartTime(ev.target.value);
                 }
@@ -180,6 +187,9 @@ const ShowingInputContainer = ({initialData, id, showingNum, handleSetShow}:MapP
             </div>
           </div>
         </div>
+        <button className='px-2 py-1 bg-red-500 disabled:opacity-30  mt-2 mb-4 text-white rounded-lg text-sm' type='button' onClick={handleDeleteShow} id={String(id)}>
+          Delete
+        </button>
       </div>
     </div>
   );

--- a/client/src/components/Ticketing/ticketingmanager/Events/showingInputContainer.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/showingInputContainer.tsx
@@ -2,6 +2,7 @@
 import React, {useEffect} from 'react';
 import {useState} from 'react';
 import {Showing} from '../../../../interfaces/showing.interface';
+import DeleteConfirm from './deleteConfirm';
 
 /**
  * Used to map props to input container correctly
@@ -62,6 +63,7 @@ const ShowingInputContainer = ({showingData, id, handleSetShow, handleDeleteShow
   const [seatsForType, setSeatsForType] = useState([]); // TODO: Fill this initial data out to properly load
   const [availableSeats, setAvailableSeats] = useState(showingData.availableseats !== undefined ? showingData.availableseats : 0);
   const [totalSeats, setTotalSeats] = useState(showingData.totalseats !== undefined ? showingData.totalseats : 0);
+  const [showConfirm, setShowConfirm] = useState(false);
 
   const [ticketTypes, setTicketTypes] = useState([]);
 
@@ -93,7 +95,7 @@ const ShowingInputContainer = ({showingData, id, handleSetShow, handleDeleteShow
 
   const handleAddTicketOption = (e) => {
     setSeatsForType((data) => [...data, 0]);
-    setTicketTypeId((data) => [...data, 0]);
+    setTicketTypeId((data) => [...data, 'NaN']);
   };
 
   const handleSeatChange = (e) => {
@@ -116,12 +118,16 @@ const ShowingInputContainer = ({showingData, id, handleSetShow, handleDeleteShow
 
   const handleChangeOption = (e) => {
     const newList = [...ticketTypeId];
-    newList[e.target.id] = parseInt(e.target.value);
+    if (e.target.value === 'Select Ticket Type') newList[e.target.id] = 'NaN';
+    else newList[e.target.id] = parseInt(e.target.value);
     setTicketTypeId(newList);
   };
 
   return (
     <div className='bg-violet-200 rounded-xl p-10 shadow-md mb-4' key={id}>
+      { showConfirm ?
+      <DeleteConfirm message='Are you sure you want to delete this showing?' setShowConfirm={setShowConfirm} handleDelete={handleDeleteShow} id={String(id)}/> : null
+      }
       <div key={id} className='shadow-xl p-5 rounded-xl mb-9 bg-violet-700'>
         <label className='font-semibold text-white mb-7 mt-7  '>Show # {id + 1}</label>
         <div className='flex flex-col gap-5 mt-5 md:pr-20'>
@@ -139,6 +145,7 @@ const ShowingInputContainer = ({showingData, id, handleSetShow, handleDeleteShow
             }
           />
           <div className='w-full'>
+
             <div className='toAdd flex flex-col gap-5 md:pr-20 w-full' id='toAdd'></div>
             {
               seatsForType.map((seats, i) => (
@@ -192,7 +199,7 @@ const ShowingInputContainer = ({showingData, id, handleSetShow, handleDeleteShow
             </div>
           </div>
         </div>
-        <button className='px-2 py-1 bg-red-500 disabled:opacity-30  mt-2 mb-4 text-white rounded-lg text-sm' type='button' onClick={handleDeleteShow} id={String(id)}>
+        <button className='px-2 py-1 bg-red-500 disabled:opacity-30  mt-2 mb-4 text-white rounded-lg text-sm' type='button' onClick={() => setShowConfirm(true)} id={String(id)}>
           Delete
         </button>
       </div>

--- a/client/src/components/Ticketing/ticketingmanager/Events/showingInputContainer.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/showingInputContainer.tsx
@@ -101,8 +101,7 @@ const ShowingInputContainer = ({showingData, id, handleSetShow, handleDeleteShow
     if (parseInt(e.target.value) >= 0) {
       newSeats[parseInt(e.target.id)] = parseInt(e.target.value);
       setSeatsForType(newSeats);
-    }
-    else {
+    } else {
       newSeats[parseInt(e.target.id)] = 0;
       setSeatsForType(newSeats);
     }

--- a/client/src/components/Ticketing/ticketingmanager/Events/showingInputContainer.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/showingInputContainer.tsx
@@ -7,16 +7,30 @@ import {Showing} from '../../../../interfaces/showing.interface';
  * Used to map props to input container correctly
  *
  * @module
- * @param {initialData} Showing
+ * @param {initialData} object
  * @param {number} id
  * @param {Function} handleSetShow
  */
+interface InitialData {
+  availableseats?: number,
+  defaulttickettype?: number,
+  eventdate?: number | string,
+  eventid_fk?: number,
+  eventinstanceid?: number,
+  eventtime?: string,
+  ispreview?: boolean,
+  purchaseuri?: string,
+  salestatus?: boolean,
+  totalseats?: number
+}
+
 export interface MapPropsToShowingInputContainer {
-  initialData?: Showing;
+  initialData: InitialData;
   id: number;
   showingNum: number;
   handleSetShow: (show: Showing) => void;
 }
+
 
 /**
  *
@@ -24,11 +38,17 @@ export interface MapPropsToShowingInputContainer {
  * @returns {ReactElement}
  */
 // eslint-disable-next-line react/prop-types
+
+const toDateStringFormat = (date) => {
+  const dateString = String(date);
+  return `${dateString.slice(0, 4)}-${dateString.slice(4, 6)}-${dateString.slice(6, 8)}`;
+};
+
 const ShowingInputContainer = ({initialData, id, showingNum, handleSetShow}:MapPropsToShowingInputContainer) => {
-  const [starttime, setStartTime] = useState(initialData.starttime !== undefined? initialData.starttime: '');
-  const [eventdate, setEventDate] = useState(initialData.eventdate !== undefined? initialData.eventdate: '');
-  const [ticketTypeId, setTicketTypeId] = useState([]);
-  const [seatsForType, setSeatsForType] = useState([]);
+  const [starttime, setStartTime] = useState(initialData.eventtime !== undefined? initialData.eventtime.slice(0, 8): '');
+  const [eventdate, setEventDate] = useState(initialData.eventdate !== undefined? toDateStringFormat(initialData.eventdate) : '');
+  const [ticketTypeId, setTicketTypeId] = useState([]); // TODO: Fill this initial data out to properly load
+  const [seatsForType, setSeatsForType] = useState([]); // TODO: Fill this initial data out to properly load
   const [availableSeats, setAvailableSeats] = useState(initialData.availableseats !== undefined? initialData.availableseats: 0);
   const [totalSeats, setTotalSeats] = useState(initialData.totalseats !== undefined? initialData.totalseats: 0);
 
@@ -49,7 +69,7 @@ const ShowingInputContainer = ({initialData, id, showingNum, handleSetShow}:MapP
   useEffect(() => {
     const showing: Showing = {
       id: id,
-      eventid: initialData.eventid,
+      eventid: initialData.eventid_fk,
       starttime: starttime,
       eventdate: eventdate,
       ticketTypeId: ticketTypeId,

--- a/client/src/components/Ticketing/ticketingmanager/Events/showingInputContainer.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/showingInputContainer.tsx
@@ -9,34 +9,31 @@ import {Showing} from '../../../../interfaces/showing.interface';
  * @module
  * @param {initialData} Showing
  * @param {number} id
- * @param {Function} addShow
- * @param {Function} deleteShow
+ * @param {Function} handleSetShow
  */
 export interface MapPropsToShowingInputContainer {
   initialData?: Showing;
   id: number;
   showingNum: number;
-  addShow: (show:Showing) => void;
-  deleteShow: (event: Event) => void;
+  handleSetShow: (show: Showing) => void;
 }
 
 /**
  *
- * @param {MapPropsToShowingInputContainer} {initialData, id, addShow, deleteShow}
+ * @param {MapPropsToShowingInputContainer} {initialData, id, handleSetShow}
  * @returns {ReactElement}
  */
 // eslint-disable-next-line react/prop-types
-const ShowingInputContainer = ({initialData, id, showingNum, addShow, deleteShow}:MapPropsToShowingInputContainer) => {
-  const [starttime, setStarttime] = useState(initialData.starttime !== undefined? initialData.starttime: '');
-  const [eventdate, setEventdate] = useState(initialData.eventdate !== undefined? initialData.eventdate: '');
-  const [ticketTypeId, setTicketTypeId] = useState('');
-  const [totalseats, setTotalseats] = useState(initialData.totalseats !== undefined? initialData.totalseats: 0);
-  const availableseates = initialData.availableseats !== undefined? initialData.availableseats: 0;
+const ShowingInputContainer = ({initialData, id, showingNum, handleSetShow}:MapPropsToShowingInputContainer) => {
+  const [starttime, setStartTime] = useState(initialData.starttime !== undefined? initialData.starttime: '');
+  const [eventdate, setEventDate] = useState(initialData.eventdate !== undefined? initialData.eventdate: '');
+  const [ticketTypeId, setTicketTypeId] = useState([]);
+  const [seatsForType, setSeatsForType] = useState([]);
+  const [availableSeats, setAvailableSeats] = useState(initialData.availableseats !== undefined? initialData.availableseats: 0);
+  const [totalSeats, setTotalSeats] = useState(initialData.totalseats !== undefined? initialData.totalseats: 0);
+
   const [ticketTypes, setTicketTypes] = useState([]);
 
-  // Index of seatsForType match typesForShow so seatsForType[0] is for typesForShow[0]
-  let seatsForType = []; // Number of seats for certian type of ticket
-  let typesForShow = []; // Ticket types for all showings
 
   const dateFieldValue = typeof eventdate === 'string' ? eventdate.split('T') : '';
   const fetchTicketTypes = async () => {
@@ -49,105 +46,44 @@ const ShowingInputContainer = ({initialData, id, showingNum, addShow, deleteShow
     fetchTicketTypes();
   }, [initialData]);
 
-  // Gets ticket types and seats for types before sending to parent component
-  const addToArray = (e) => {
-    seatsForType = [];
-    typesForShow = [];
-    const div = e.target.parentElement;
-    const inputs = div.querySelectorAll('input');
-    const selects = div.querySelectorAll('select');
-    const len = inputs.length - 2;
-    for (let i = 1; i < len; i++) {
-      seatsForType.push(parseInt(inputs[i].value));
-    }
-    selects.forEach((e: HTMLSelectElement) => {
-      typesForShow.push(parseInt(e.value));
-    });
-  };
-
-  // Generate the showing object to submit to parent component
-  const createShowObject = (id) => {
+  useEffect(() => {
     const showing: Showing = {
       id: id,
       eventid: initialData.eventid,
       starttime: starttime,
       eventdate: eventdate,
-      totalseats: totalseats,
-      availableseats: availableseates? availableseates : totalseats,
-      ticketTypeId: typesForShow,
+      ticketTypeId: ticketTypeId,
       seatsForType: seatsForType,
+      availableseats: availableSeats ? availableSeats : totalSeats,
+      totalseats: totalSeats,
       salestatus: true,
     };
-    console.log(showing);
-    return showing;
+    handleSetShow(showing);
+  }, [starttime, eventdate, ticketTypeId, totalSeats, availableSeats, seatsForType]);
+
+
+  const handleAddTicketOption = (e) => {
+    setSeatsForType((data) => [...data, 0]);
+    setTicketTypeId((data) => [...data, 0]);
   };
 
-  // Send callback to parent
-  const handleClick = (event) => {
-    event.preventDefault();
-    //  use call back to get to parent state
-    addToArray(event);
-    addShow(createShowObject(id));
+  const handleSeatChange = (e) => {
+    const newSeats = [...seatsForType];
+    newSeats[parseInt(e.target.id)] = parseInt(e.target.value);
+    setSeatsForType(newSeats);
   };
 
-  const handleDelete = (event) => {
-    event.preventDefault();
-    deleteShow(event);
+  const handleRemove = (e) => {
+    const newSeats = seatsForType.filter((seat, i) => i !== parseInt(e.target.value));
+    const newTypes = ticketTypeId.filter((ticketType, i) => i !== parseInt(e.target.value));
+    setSeatsForType(newSeats);
+    setTicketTypeId(newTypes);
   };
 
-  // Uses ticketTypes array to map out option (used by addElement)
-  const createTicketOptions = (select: HTMLSelectElement) :HTMLSelectElement=> {
-    ticketTypes.map((t) => {
-      const newOp = document.createElement('option');
-      if (t.id == ticketTypeId) {
-        newOp.setAttribute('key', t.id);
-        newOp.setAttribute('value', t.id);
-        newOp.text = `${t.description}: ${t.price} (+ ${t.concessions} concessions)`;
-      } else {
-        newOp.setAttribute('key', t.id);
-        newOp.setAttribute('value', t.id);
-        newOp.text = `${t.description}: ${t.price} (+ ${t.concessions} concessions)`;
-      }
-      select.appendChild(newOp);
-    });
-    return select;
-  };
-
-  // Adds a ticket type input container to element
-  const addElement = (e) => {
-    const div = e.target.parentElement.firstChild;
-    const newDiv = document.createElement('div');
-    const input = document.createElement('input');
-    input.setAttribute('class', 'input rounded-lg p-2 bg-violet-100 w-full flex flex-col');
-    input.setAttribute('name', 'numInput');
-    input.setAttribute('type', 'number');
-    input.setAttribute('placeholder', '# of Seats');
-    let select = document.createElement('select');
-    select.setAttribute('class', 'p-2 rounded-lg bg-violet-100');
-    select.setAttribute('name', 'typeSelect');
-    const options = document.createElement('option');
-    options.setAttribute('class', 'text-sm text-zinc-700');
-    options.text = 'Select Ticket Type';
-    const removeBut = document.createElement('button');
-    removeBut.textContent = 'Remove';
-    removeBut.setAttribute('class', 'w-min block px-2 py-1 bg-red-500 disabled:opacity-30 mb-4 text-white rounded-lg text-sm');
-    removeBut.setAttribute('type', 'button');
-    removeBut.addEventListener('click', removeElement);
-    select.appendChild(options);
-    select = createTicketOptions(select);
-
-    newDiv.appendChild(input);
-    newDiv.appendChild(select);
-    newDiv.appendChild(removeBut);
-    newDiv.setAttribute('class', 'flex flex-col gap-5 mt-2 md:pr-20 bg-violet-800 rounded-xl p-2 pt-5');
-
-    div.appendChild(newDiv);
-  };
-
-  // Removes a specified ticket type input container
-  const removeElement = (e) => {
-    const curDiv = e.target.parentElement;
-    curDiv.remove();
+  const handleOptionChange = (e) => {
+    const newList = [...ticketTypeId];
+    newList[e.target.id] = parseInt(e.target.value);
+    setTicketTypeId(newList);
   };
 
   return (
@@ -158,21 +94,51 @@ const ShowingInputContainer = ({initialData, id, showingNum, addShow, deleteShow
           <h3 className='font-semibold text-white'>Total Tickets For Showing</h3>
           <input
             className='input rounded-lg p-2 bg-violet-100 w-full md:w-7/8'
-            value={totalseats}
+            value={totalSeats}
             name={`${initialData.eventdate}`}
             type='number'
             required
             placeholder='# of Seats'
-            onChange={(ev: React.ChangeEvent<HTMLInputElement>): void =>
-              setTotalseats(parseInt(ev.target.value))
+            onChange={(ev: React.ChangeEvent<HTMLInputElement>): void => {
+              if (isNaN(parseInt(ev.target.value))) setTotalSeats(0);
+              if (parseInt(ev.target.value) >= 0) setTotalSeats(parseInt(ev.target.value));
+            }
             }
           />
           <div className='w-full'>
             <div className='toAdd flex flex-col gap-5 md:pr-20 w-full' id='toAdd'></div>
+            {seatsForType.length > 0 ?
+                seatsForType.map((seats, i) => (
+                  <div key={i} className='flex flex-col gap-5 mt-2 md:pr-20 bg-violet-800 rounded-xl p-2 pt-5'>
+                    <input
+                      id={String(i)}
+                      className='input rounded-lg p-2 bg-violet-100 w-full flex flex-col'
+                      name='numInput'
+                      type='number'
+                      placeholder='# of Seats'
+                      onChange={handleSeatChange}
+                      value={seatsForType[i]}
+                    >
+                    </input>
+                    <select className='p-2 rounded-lg bg-violet-100' name='typeSelect' onChange={handleOptionChange} id={String(i)} value={ticketTypeId[i]}>
+                      <option className='text-sm text-zinc-700'>
+                        Select Ticket Type
+                      </option>
+                      {ticketTypes.map((ticketType, j) => <option key={j} className='text-sm text-zinc-700' value={ticketType.id}>
+                        {ticketType.description}: {ticketType.price} (+{ticketType.concessions} concessions)
+                      </option>)}
+                    </select>
+                    <button className='w-min block px-2 py-1 bg-red-500 disabled:opacity-30 mb-4 text-white rounded-lg text-sm'
+                      type='button' onClick={handleRemove} value={i}>
+                      Remove
+                    </button>
+                  </div>)):
+              null
+            }
             <button className='block px-2 py-1 bg-blue-500 disabled:opacity-30
               mt-4 mb-2 text-white rounded-lg text-sm'
             type='button'
-            onClick={addElement}>Add Ticket Option</button>
+            onClick={handleAddTicketOption}>Add Ticket Option</button>
           </div>
           <div className="flex md:flex-row gap-10 flex-col">
             <div>
@@ -180,7 +146,7 @@ const ShowingInputContainer = ({initialData, id, showingNum, addShow, deleteShow
               <input type="date" id="date" className='input w-full p-2 rounded-lg bg-violet-100 mb-7'
                 value={dateFieldValue[0]}
                 onChange={(ev: React.ChangeEvent<HTMLInputElement>): void => {
-                  setEventdate(ev.target.value);
+                  setEventDate(ev.target.value);
                 } }/>
             </div>
             <div >
@@ -188,24 +154,12 @@ const ShowingInputContainer = ({initialData, id, showingNum, addShow, deleteShow
               <input type="time" id="time" name="starttime" placeholder='00:00:00'className='w-full p-2 rounded-lg bg-violet-100 mb-7 '
                 value={starttime}
                 onChange={(ev: React.ChangeEvent<HTMLInputElement>): void =>{
-                  setStarttime(ev.target.value);
+                  setStartTime(ev.target.value);
                 }
                 }/>
             </div>
           </div>
         </div>
-        <button
-          className='px-2 py-1 bg-blue-500 disabled:opacity-30  mt-2 mb-4 text-white rounded-lg text-sm'
-          onClick={handleClick}
-        >
-                    Save
-        </button>
-        <button
-          className='px-2 py-1 bg-red-500 disabled:opacity-30 ml-9 mt-2 mb-4 text-white rounded-lg text-sm'
-          onClick={handleDelete}
-        >
-                        Delete
-        </button>
       </div>
     </div>
   );

--- a/client/src/interfaces/showing.interface.ts
+++ b/client/src/interfaces/showing.interface.ts
@@ -15,7 +15,7 @@ export interface Showing {
     starttime: string,
     eventdate: string,
     salestatus: boolean,
-    ticketTypeId: number[],
+    ticketTypeId: (string | number)[],
     seatsForType: number[],
     totalseats: number,
     availableseats: number

--- a/server/src/api/events/event.service.ts
+++ b/server/src/api/events/event.service.ts
@@ -323,8 +323,8 @@ export const createEvent = async (params: any): Promise<response> => {
                 eventname,
                 eventdescription,
                 active,
-                seasonticketeligible,
-                imageurl)
+                imageurl
+                )
           VALUES
             ($1, $2, $3, true, $4, $5)
           RETURNING *;`,
@@ -333,7 +333,8 @@ export const createEvent = async (params: any): Promise<response> => {
       params.eventName,
       params.eventDesc,
       params.seasonticketeligible,
-      params.imageUrl],
+      params.imageUrl
+    ],
   };
   return buildResponse(myQuery, 'POST');
 };
@@ -406,16 +407,27 @@ export const insertAllShowings = async (showings: Showing[]): Promise<Showing[]>
   };
   const toReturn = [];
   let rowCount = 0;
+  // Using 2020-01-01 as a default value or it will not save
+  let dateAct = '20200101'
+  let startTime = '00:00'
   for (const showing of showings) {
-    if (showing.ticketTypeId.length === 0) {
-      throw new Error('No ticket type provided');
+    if (showing.eventdate !== '') {
+      const date = showing.eventdate.split('-');
+      dateAct = date.join('');
     }
-    const date = showing.eventdate.split('-');
-    const dateAct = date.join('');
+    else {
+      dateAct = '20200101'
+    }
+    if (showing.starttime !== '') {
+      startTime = showing.starttime
+    }
+    else {
+      startTime = '00:00'
+    }
     const {rows} = await pool.query(query, [
       showing.eventid,
       dateAct,
-      showing.starttime,
+      startTime,
       showing.totalseats,
       showing.totalseats,
       showing.ispreview,
@@ -435,7 +447,6 @@ export const insertAllShowings = async (showings: Showing[]): Promise<Showing[]>
       } inserted.`,
     },
   };
-  console.log(results);
   return res;
 };
 

--- a/server/src/api/events/event.service.ts
+++ b/server/src/api/events/event.service.ts
@@ -323,6 +323,7 @@ export const createEvent = async (params: any): Promise<response> => {
                 eventname,
                 eventdescription,
                 active,
+                seasonticketeligible,
                 imageurl
                 )
           VALUES


### PR DESCRIPTION
## Brief Description

Use this event fix instead, there was too many changes in the other one. 

- Refactored showingInputContainer to use hooks and conditional rendering instead of vanilla JS DOM. 
- Cleaned up code
- Allows user to save event without clicking the save button for each showing
- Saving data with the edit button now sends to sever using this format
  - ![image](https://user-images.githubusercontent.com/62050214/225426323-c0ae3179-7f7f-41c1-9321-740ac18d3df7.png)
- Clicking edit will correctly display time and date
- Fixed bugs regarding removing shows.

## References Issue

Issue #145 

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Major change (potentially breaking, list anything that is broken below)
- [ ] Documentation

### Breaking Changes

Editing still does not work because the eventid is undefined when editing. 
Edit looks like it takes in a different object.

## Testing done

Describe tests that were used, along with instructions for testing.

- [ ] Test1
- [ ] Test2
...

- [ ] Docker was used.
- [ ] Docker was not used and I have listed my configuration below.

**System Specifications**:
* Operating System:
* Node Version:
* NPM Version:

## Checklist:

- [ ] My code follows the styling guidelines.
- [ ] I have added unit tests and verified that they pass.
- [ ] I have used the linter and fixed any linting issues.
- [ ] I have commented the code.
- [ ] I have adjusted the documentation to match the changed code.
- [ ] Prior to submitting the PR, I made sure the latest changes were merged with my branch.
- [ ] Existing tests pass locally with changes.

### Explanation for unchecked

Provide a brief explanation for why the checklist was not completed.

## Additional information: 

The select ticket type now defaults to pay what can, and not select ticket type
