### PR TITLE
update readme with new docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,41 @@
 # WonderTix
-
-For the most current stable version see the 'main' branch.
+Main branch is the latest stable release. Develop branch is the latest development release.
 
 ## Overview
-Wondertix is a full-featured ticket sales platform and CRM built for Portland Playhouse. It consists of a user ticketing system as well as both ticketing and CRM administrative panels. This project serves a variety of purposes including managing task assignments, financial reporting, and handling ticket sales. Future features include managing/creating email campaigns and ticket exchanges. 
+WonderTix is a full-featured ticket sales platform and CRM built for Portland Playhouse. 
+It consists of a user ticketing system as well as both ticketing and CRM administrative panels. 
+This project serves a variety of purposes including managing task assignments, financial reporting, and handling ticket sales. 
+Future features include managing/creating email campaigns and ticket exchanges. 
+
+## Requirements
+- [Docker Desktop](https://www.docker.com/products/docker-desktop)
+- mkcert
+  - Mac: install with [Brew](https://brew.sh) `brew install mkcert nss`
+  - Windows: install with [Chocolatey](https://chocolatey.org) `choco install mkcert`
+  - Linux: install with your favorite package manager. If mkcert is not available using your favorite package manager, run the following:
+    ```
+    curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"
+    chmod +x mkcert-v*-linux-amd64
+    sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
+    ```
 
 ## Setup
-There are two says to set this project up. Either directly by installing postgres and using npm, or by using docker. Docker is by far the easier method of installation.
-
-### SSL Keys for localhost
-#### Install mkcert
-##### Mac
-Make sure you have [Brew](https://brew.sh) installed and run `brew install mkcert nss`
-##### Windows
-Make sure you have [Chocolatey](https://chocolatey.org) installed and run `choco install mkcert`
-##### Linux
-Using your favorite package manager, install mkcert. If mkcert is not available using your favorite package manager, run the following:
-```
-curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"
-chmod +x mkcert-v*-linux-amd64
-sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
-```
-
-#### Generate certificates
-Run the following commands:
-```
-mkcert -install
-cd <path/to/WonderTix/client>
-mkcert localhost
-```
-This will install the CA for the mkcert certificate and create a certificate for localhost. The application is set to use the `localhost.pem` file for SSL. Copy `localhost.pem` and `localhost-key.pem` to your `server` directory as well for future changes to SSL on the backend.  
-
-### Docker Setup
-1. Install [Docker](https://docs.docker.com/engine/install/ubuntu/)
-2. Clone the repository
-3. !!!IMPORTANT!!! Run setup.py
-4. Run `sudo docker-compose up` ( `docker compose up`  if you're not on Linux)
-
-If you do not run `setup.py` and run `docker-compose up`, you may need to run `docker-compose down --volumes` before running `docker-compose up` again. 
-
-### Standalone Setup
-Standalone setup is a little bit more involved. 
-
-1. Install [nodejs and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) 
-2. [Download and install Postgres](https://www.postgresql.org/download/)
-3. Run setup.py
-4. Make sure Postgres is running and create a user and table with the information specified when running setup.py
-5. From the root of the WonderTix project, run `psql -f task_sql/create_task_table.sql`
-6. From the root of the WonderTix project, run `psql -f task_sql/wtix_dump_030422.sql`
-7. Go into the client folder and run `npm install && npm run start`
-8. In a new terminal window, go into the server folder and run `npm install && npm run dev`
+1. Clone the repository.
+2. Copy `.env.dist` to `.env`
+   1. Set the values for `AUTH0_CLIENT_ID` and `AUTH0_CLIENT_SECRET`. *you can get these values from the team lead*
+   2. set the value for `PRIVATE_STRIPE_KEY` *you can get this value from the team lead*
+3. In `<path/to/WonderTix/server>` Run `mkcert -install` to install the local certificate authority
+4. Run `docker-compose up -d`
+5. The client will be available at https://localhost:3000 
+   1. You will need to accept the self-signed certificate. In chrome click anywhere on the page and type `thisisunsafe`. This will allow you to continue to the site.
+6. The server will be available at https://localhost:8000
+7. The swagger docs will be available at https://localhost:8000/api/docs
+   1. To log in to swagger, login to the client and copy the value of the `access_token` from the request to `<AUTH0_URL>/oath/token`. Paste this value into the `Authorize` dialog in swagger.
 
 ## Troubleshooting
 This list will be updated as new issues arise. If you your issue is not listed, please create an issue and we will look into it.
 
-### I ran docker-compose up and it says it can't connect to postgres
-Make sure that you ran `setup.py`. If you ran `setup.py`, run `docker-compose down --volumes` and try again.
+### Changes are not being reflected
+The client and server are built with docker. In most cases you can restart the containers with `docker-compose restart`. 
+
+If that does not work, you can try `docker-compose down`, `docker-compose build --no-cache`, `docker compose up -d --build`.


### PR DESCRIPTION
This is just a document update to the readme.

I am removing the instructions for local installs to simplify things. Docker is preferred to ensure everyone is on the same version of dependencies. 

Changed the headings to a simple list.

Included information about `.env` file, swagger docs and having to type `thisisunsafe`