### PR TITLE
Edit ticket types

### DIFF
--- a/server/src/api/ticket_types/ticket_types.router.ts
+++ b/server/src/api/ticket_types/ticket_types.router.ts
@@ -1,0 +1,83 @@
+import {Router, Request, Response} from 'express';
+import {checkJwt, checkScopes} from '../../auth';
+import TicketType from '../../models/TicketType';
+import {pool} from '../db';
+
+export const ticketTypesRouter = Router();
+
+/**
+ * @swagger
+ *  /ticket-types/{id}:
+ *    put:
+ *      summary: update ticket type
+ *      tags:
+ *        - TicketTypes
+ *      security:
+ *        - bearerAuth: []
+ *      parameters:
+ *      - in: path
+ *        name: id
+ *      requestBody:
+ *        required: true
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                description: {type: string}
+ *                price: {type: number}
+ *                concessions: {type: number}
+ *                deprecated: {type: boolean}
+ *      responses:
+ *        204:
+ *          description: OK
+ *        401:
+ *          description: Unauthorized
+ *        404:
+ *          description: Not Found
+ *        500:
+ *          description: Internal Server Error
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  error: {type: string}
+ */
+ticketTypesRouter.put('/:id', checkJwt, checkScopes, async (req, res) => {
+  try {
+    if (req.body.description === undefined) {
+      res.status(400).send({error: 'Missing description field'});
+      return;
+    }
+    if (req.body.price === undefined) {
+      res.status(400).send({error: 'Missing price field'});
+      return;
+    }
+    if (req.body.concessions === undefined) {
+      res.status(400).send({error: 'Missing concessions field'});
+      return;
+    }
+    if (req.body.deprecated === undefined) {
+      res.status(400).send({error: 'Missing deprecated field'});
+      return;
+    }
+
+    const id = Number(req.params.id);
+    const currentTicketType: boolean|TicketType = await TicketType.find(pool, id);
+    if ( !currentTicketType ) {
+      res.sendStatus(404);
+      return;
+    }
+
+    const updatedTicketType: TicketType = currentTicketType as TicketType;
+    updatedTicketType.description = req.body.description;
+    updatedTicketType.price = req.body.price;
+    updatedTicketType.concessions = req.body.concessions;
+    updatedTicketType.deprecated = req.body.deprecated;
+    await updatedTicketType.update();
+    res.status(204).send();
+  } catch (error: any) {
+    res.status(500).send({error: error.message});
+  }
+});

--- a/server/src/models/TicketType.ts
+++ b/server/src/models/TicketType.ts
@@ -1,0 +1,155 @@
+import {Pool} from 'pg';
+
+/**
+ * TicketType class
+ * @class TicketType
+ */
+export default class TicketType {
+  private _pool: Pool;
+  private _id: number = 0;
+  private _description: string = '';
+  private _price: number = 0;
+  private _concessions: number = 0;
+  private _deprecated: boolean = false;
+
+  /**
+   * TicketType constructor
+   * @param {Pool} pool - database pool connection object
+   */
+  constructor(pool: Pool) {
+    this._pool = pool;
+  }
+
+  /**
+   * Get the id of the ticket type
+   * @return {number}
+   */
+  get id(): number {
+    return this._id;
+  }
+
+  /**
+   * Set the id of the ticket type
+   * @param {number} value
+   */
+  set id(value: number) {
+    this._id = value;
+  }
+
+  /**
+   * Get the description of the ticket type
+   * @return {string}
+   */
+  get description(): string {
+    return this._description;
+  }
+
+  /**
+   * Set the description of the ticket type
+   * @param {string} value
+   */
+  set description(value: string) {
+    this._description = value;
+  }
+
+  /**
+   * Get the price of the ticket type
+   * @return {decimal}
+   */
+  get price(): number {
+    return this._price;
+  }
+
+  /**
+   * Set the price of the ticket type
+   * @param {number} value
+   */
+  set price(value: number) {
+    this._price = value;
+  }
+
+  /**
+   * Get the concessions of the ticket type
+   * @return {number}
+   */
+  get concessions(): number {
+    return this._concessions;
+  }
+
+  /**
+   * Set the concessions of the ticket type
+   * @param {number} value
+   */
+  set concessions(value: number) {
+    this._concessions = value;
+  }
+
+  /**
+   * Get the deprecated flag of the ticket type
+   * @return {boolean}
+   */
+  get deprecated(): boolean {
+    return this._deprecated;
+  }
+
+  /**
+   * Set the deprecated flag of the ticket type
+   * @param {boolean} value
+   */
+  set deprecated(value: boolean) {
+    this._deprecated = value;
+  }
+
+  /**
+   * Create a new ticket type
+   * @param {Pool} pool - database pool connection object
+   * @param {Number} id - id of the ticket type
+   * @return {boolean|TicketType} - false if ticket type not found, otherwise the ticket type
+   */
+  static async find(pool: Pool, id: number): Promise<boolean|TicketType> {
+    const result = await pool.query(
+        `SELECT tickettypeid, description, price, concessions, deprecated 
+        FROM tickettype 
+        WHERE tickettypeid = $1`,
+        [id],
+    );
+
+    if (result.rowCount === 0) {
+      return false;
+    }
+
+    const ticketType = new TicketType(pool);
+    ticketType.id = result.rows[0].tickettypeid;
+    ticketType.description = result.rows[0].description;
+    ticketType.price = result.rows[0].price;
+    ticketType.concessions = result.rows[0].concessions;
+    ticketType.deprecated = result.rows[0].deprecated;
+
+    return ticketType;
+  }
+
+  /**
+   * Update an existing ticket type
+   */
+  async update(): Promise<boolean> {
+    await this._pool.query(
+        `UPDATE 
+        tickettype 
+      SET
+        description = $2,
+        price = $3,
+        concessions = $4,
+        deprecated = $5
+      WHERE 
+        tickettypeid = $1;`,
+        [
+          this.id,
+          this.description,
+          this.price,
+          this.concessions,
+          this.deprecated,
+        ]);
+
+    return true;
+  }
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -36,6 +36,7 @@ import {reportingRouter} from './api/reporting/reporting.router';
 import {refundsRouter} from './api/refunds/refunds.router';
 import swaggerJsdoc from 'swagger-jsdoc';
 import swaggerUi from 'swagger-ui-express';
+import {ticketTypesRouter} from "./api/ticket_types/ticket_types.router";
 
 const openapiSpecification = swaggerJsdoc({
   definition: {
@@ -103,6 +104,7 @@ const createServer = async () => {
   app.use('/api/events', eventRouter);
   app.use('/api/email_subscriptions', subscriptionRouter);
   app.use('/api/tickets', ticketRouter);
+  app.use('/api/ticket-types', ticketTypesRouter);
   app.use('/api/doorlist', doorlistRouter);
   app.use('/api/discounts', discountsRouter);
   app.use('/api/refunds', refundsRouter);


### PR DESCRIPTION
## Brief Description

Adds a new router with a route for editing an existing ticket type.

`PUT /api/ticket-types/{id}`

## References Issue

Issue #

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Major change (potentially breaking, list anything that is broken below)
- [x] Documentation

### Breaking Changes

All code is new so no BC changes.

## Testing done

Describe tests that were used, along with instructions for testing.

- [x] Manually tested in swagger docs
...

## Checklist:

- [x] My code follows the styling guidelines.
- [ ] I have added unit tests and verified that they pass.
- [x] I have used the linter and fixed any linting issues.
- [x] I have commented the code.
- [x] I have adjusted the documentation to match the changed code.
- [x] Prior to submitting the PR, I made sure the latest changes were merged with my branch.
- [ ] Existing tests pass locally with changes.

### Explanation for unchecked

No tests written because they have been written to focus on the [standardization task](https://github.com/WonderTix/WonderTix/issues/222) which may do things differently as a v2 api.

## Additional information: 

This is done in a new router to have `ticket-types` as the resource in the url. The ticket router includes routes for tickets and tickettypes adding some confusion. The ticket type related routes should be moved over to the new router or we should just focus on a new api, deprecating the old one. 
