### PR TITLE
fix documentation and order of showings for edit showing

### DIFF
--- a/server/src/api/events/event.service.ts
+++ b/server/src/api/events/event.service.ts
@@ -51,7 +51,7 @@ export const getInstanceById = async (params: any): Promise<response> => {
           AND
             salestatus = true
           ORDER BY
-            eventid_fk;`,
+            eventinstanceid;`,
     values: [params.id],
   };
   return await buildResponse(query, "GET");

--- a/server/src/api/tickets/ticket.router.ts
+++ b/server/src/api/tickets/ticket.router.ts
@@ -373,14 +373,14 @@ ticketRouter.delete('/:id', checkJwt, checkScopes, async (req, res) => {
  * @swagger
  *  /1/tickets/restrictions/{eventid}:
  *    get:
- *      summary: Delete ticket type
+ *      summary: get number of tickets in each ticket type for an event instance (a showing)
  *      tags:
  *        - Tickets
  *      security:
  *        - bearerAuth: []
  *      parameters:
  *      - in: path
- *        name: eventid
+ *        name: eventinstanceid
  *      responses:
  *        200:
  *          description: OK
@@ -402,12 +402,12 @@ ticketRouter.delete('/:id', checkJwt, checkScopes, async (req, res) => {
  *        404:
  *          description: Not Found
  */
-ticketRouter.get('/restrictions/:eventid', async(req, res) => {
+ticketRouter.get('/restrictions/:eventinstanceid', async(req, res) => {
   let ticketquery = `
     SELECT * FROM ticketrestrictions where eventinstanceid_fk = $1
   `;
   try { 
-    let result = await pool.query(ticketquery, [req.params.eventid]);
+    let result = await pool.query(ticketquery, [req.params.eventinstanceid]);
     
     let resp = {
       data: result.rows,


### PR DESCRIPTION
## Brief Description

edit event works but when a showing is edited, it would go to the bottom of the page as the last showing because the query to get the event instance ordered it by eventID. If you click on a showing, the eventid for each event instance (showing) would be 32 (for example). This means when you edit a showing, it would put that showing last so when you click edit again, it would put that updated showing to the end. This edit orders it by eventinstanceID so it will stay consistent on the page even after editing.

## References Issue

Issue #

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Major change (potentially breaking, list anything that is broken below)
- [ ] Documentation

### Breaking Changes

Briefly list things that were broken as a result of this PR.

## Testing done

Describe tests that were used, along with instructions for testing.

- [ ] Test1
- [ ] Test2
...

- [ ] Docker was used.
- [ ] Docker was not used and I have listed my configuration below.

**System Specifications**:
* Operating System:
* Node Version:
* NPM Version:

## Checklist:

- [ ] My code follows the styling guidelines.
- [ ] I have added unit tests and verified that they pass.
- [ ] I have used the linter and fixed any linting issues.
- [ ] I have commented the code.
- [ ] I have adjusted the documentation to match the changed code.
- [ ] Prior to submitting the PR, I made sure the latest changes were merged with my branch.
- [ ] Existing tests pass locally with changes.

### Explanation for unchecked

Provide a brief explanation for why the checklist was not completed.

## Additional information: 

Provide any additional information that might be useful for this commit.
