### PR TITLE
[DEP-22] mkcert fixed #297

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,25 @@ Future features include managing/creating email campaigns and ticket exchanges.
 ## Setup
 
 1. Clone the repository.
-2. Create a `.env` file and copy over the contents from the `.env.dist` (.env example) file (or copy `.env.dist` to `.env` and edit)
-   1. Set the values for `AUTH0_CLIENT_ID` and `AUTH0_CLIENT_SECRET`. *you can get these values from the team lead*
-   2. Set the value for `PRIVATE_STRIPE_KEY` and `PUBLIC_STRIPE_KEY`. *you can get this value from the team lead*
-   3. Set the value for `PRIVATE_STRIPE_WEBHOOK`. *explained in step 5*
-3. In `<path/to/WonderTix/server>` Run `mkcert -install` to install the local certificate authority
-   1. Run `mkcert localhost` to create a certfiicate.
+   1. Open your command line. 
+   2. Navigate to desired folder to install WonderTix repository
+   3. Execute the following command:
+      ```
+      git clone https://github.com/WonderTix/WonderTix.git
+      ```
+
+2. Create a `.env` file and copy over the contents from the `.env.dist` (.env example) file
+   1. Set the values for `AUTH0_CLIENT_ID` and `AUTH0_CLIENT_SECRET`. *you must get these values from the team lead*
+   2. Set the value for `PRIVATE_STRIPE_KEY` and `PUBLIC_STRIPE_KEY`. *you must get this value from the team lead*
+   3. Set the value for `PRIVATE_STRIPE_WEBHOOK`. **explained in step 5**
+   4. Team Leads Auth0 Key provisioning instructions: 
+      1. Obtain access to the wtix-dev Auth0 account. 
+      2. Go to Applications > Applications > Default App
+      3. Use a secure note transfer service to send the Client ID and Client Secret to your team members. 
+3. Create mkcert certificate
+   1. Navigate to `<path/to/WonderTix/server>` 
+   2. Run `mkcert -install` to install the local certificate authority
+   3. Run `mkcert localhost` to create a certificate.   
 4. Run `docker-compose up -d`
 5. To test the checkout process with Stripe, make sure the Stripe CLI is installed.
    1. Run `stripe login` and press enter to accept access. This only needs to be done once.
@@ -59,7 +72,7 @@ Future features include managing/creating email campaigns and ticket exchanges.
 
 ## Using the WonderTix.code-workspace in VSCode
 
-Open the folder where you downloaded your repository to then:
+Open the folder where you cloned your repository to then:
 
 1. Double click the `WonderTix.code-workspace` file to open it in VSCode
 2. You can click `File -> Open Workspace from File...` to open it if VSCode is open already
@@ -74,6 +87,15 @@ Here you will see:
 4. `WonderTix Deploy`: The folder containing the deployment/terraform code
 
 This allows VSCode to keep your files organized, as well as getting the Jest tests running properly. Simply double click a folder for the project you want to work on and everything will run in that particular project, including opening a new terminal.
+
+### Using Swagger:
+1. To get the bearer token, create a user by going through the signup process. 
+   - For admin functions, make sure the user has an admin role (contact team lead for admin role).
+   - Team Leads: In the User section of Auth0, you can grant individual users an admin role.
+2. Log into the client 
+3. Once you're logged in, open the dev tools menu(Chrome), refresh the page, and find the token in the Network tab.
+4. Go to the Preview section for that token and then `copy string contents`. 
+5. Paste that into the bearerAuth input in Swagger (https://localhost:8000/api/docs).
 
 ## Troubleshooting
 

--- a/client/package.json
+++ b/client/package.json
@@ -2,10 +2,6 @@
   "name": "wondertix-crm",
   "version": "0.1.0",
   "private": true,
-  "engines": {
-    "node": ">=18.0.0",
-    "npm": ">=8.0.0"
-  },
   "dependencies": {
     "@auth0/auth0-react": "^1.10.1",
     "@emotion/react": "^11.10.5",
@@ -51,7 +47,7 @@
    
   },
   "scripts": {
-    "start": "cross-env HTTPS=true cross-env SSL_CRT_FILE=cert.pem react-scripts start",
+    "start": "cross-env HTTPS=true cross-env SSL_CRT_FILE=/usr/app/localhost.pem SSL_KEY_FILE=/usr/app/localhost-key.pem react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
### Description
Mkcert is fixed so that the certificate warning on Chrome will no longer appear. This is done by pointing SSL_CRT_FILE to /usr/app/localhost.pem and SSL_KEY_FILE to /usr/app/localhost-key.pem in the client package.json file.
This requires the user to copy the certificate keys from the server to the client folder for the docker builds to work.
Readme updated to reflect the need to copy the local certificate public and private keys into the client folder

### Risks
This requires the user to copy the certificate keys from the server to the client folder for the docker builds to work.

### Validation
Certificate Warning no longer appears. 

### Issue
#297 

### Operating System
Mac M Series