### PR TITLE
Fixed DB_USER to DB_PORT

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,4 +12,4 @@ WORKDIR /usr/app
 COPY ./package*.json .
 RUN npm install
 
-CMD /bin/bash /usr/wait-for-it.sh ${DB_HOST}:${DB_USER} -- npm run dev
+CMD /bin/bash /usr/wait-for-it.sh ${DB_HOST}:${DB_PORT} -- npm run dev


### PR DESCRIPTION
### Description
Fixed DB_USER to DB_PORT in the variable calling the wait-for-it.sh script since the docker logs were saying 'nc: invalid port postgres' and now it works fine since it's not being passed the ip:username, it's now the ip:port as it should be.

### Risks
None

### Validation
Passed on Docker, error not showing in the logs any more

### Issue
NA

### Operating System
macOS (intel) 13.0
