### PR TITLE
[TIC-38] Fixed ticketingSlice warnings and other client warnings appearing in console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,9 @@ yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
 
+# Build
+client/build
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/client/src/components/Ticketing/event/TicketPicker.tsx
+++ b/client/src/components/Ticketing/event/TicketPicker.tsx
@@ -23,20 +23,20 @@ import isSameDay from 'date-fns/isSameDay';
 import React, {ChangeEvent, useEffect, useState, useReducer} from 'react';
 
 /**
-* @module
-* @param {Date} selectedDate
-* @param {Ticket[]} displayedShowings
-* @param {Ticket} selectedTicket
-* @param {number} qty
-* @param {boolean} concessions
-* @param {TicketType[]} ticketTypes
-* @param {TicketType} selectedTicketType
-* @param {boolean} showCalendar
-* @param {boolean} showTimes
-* @param {boolean} showClearBtn
-* @param {TicketType} ticketType
-* @param prompt - 'selectDate' | 'selectTime' | 'showSelection'
-*/
+ * @module
+ * @param {Date} selectedDate
+ * @param {Ticket[]} displayedShowings
+ * @param {Ticket} selectedTicket
+ * @param {number} qty
+ * @param {boolean} concessions
+ * @param {TicketType[]} ticketTypes
+ * @param {TicketType} selectedTicketType
+ * @param {boolean} showCalendar
+ * @param {boolean} showTimes
+ * @param {boolean} showClearBtn
+ * @param {TicketType} ticketType
+ * @param prompt - 'selectDate' | 'selectTime' | 'showSelection'
+ */
 interface TicketPickerState {
     selectedDate?: Date,
     displayedShowings: Ticket[],
@@ -60,17 +60,17 @@ export interface TicketType {
 }
 
 /**
-* Initial state
-* displayedShowings: [],
-* qty: 0,
-* concessions: false,
-* ticketTypes: [],
-* selectedTicketType: null,
-* showCalendar: true,
-* showTimes: false,
-* showClearBtn: false,
-* prompt: 'selectDate',
-*/
+ * Initial state
+ * displayedShowings: [],
+ * qty: 0,
+ * concessions: false,
+ * ticketTypes: [],
+ * selectedTicketType: null,
+ * showCalendar: true,
+ * showTimes: false,
+ * showClearBtn: false,
+ * prompt: 'selectDate',
+ */
 const initialState: TicketPickerState = {
   displayedShowings: [],
   qty: 0,
@@ -99,21 +99,21 @@ const changeTicketType = (t: TicketType) => ({type: 'change_ticket_type', payloa
 let tempPay = 0;
 
 /**
-* TicketPickerReducer is meant to be used to lower ticket numbers
-* Default:
-*      ...state,
-*      selectedDate: date,
-*      selectedTicket: undefined,
-*      displayedShowings: sameDayShows,
-*      showCalendar: false,
-*      showTimes: true,
-*      showClearBtn: true,
-*      prompt: 'selectTime',
-*
-* @param state
-* @param action
-* @returns a certain default state if failed
-*/
+ * TicketPickerReducer is meant to be used to lower ticket numbers
+ * Default:
+ *      ...state,
+ *      selectedDate: date,
+ *      selectedTicket: undefined,
+ *      displayedShowings: sameDayShows,
+ *      showCalendar: false,
+ *      showTimes: true,
+ *      showClearBtn: true,
+ *      prompt: 'selectTime',
+ *
+ * @param state
+ * @param action
+ * @returns a certain default state if failed
+ */
 const TicketPickerReducer = (state: TicketPickerState, action: any): TicketPickerState => {
   switch (action.type) {
     case 'date_selected': {
@@ -162,11 +162,11 @@ interface TicketPickerProps {
 }
 
 /**
-* Used to choose the tickets
-*
-* @param {TicketPickerProps} props
-* @returns {ReactElement} and the correct ticket when picking
-*/
+ * Used to choose the tickets
+ *
+ * @param {TicketPickerProps} props
+ * @returns {ReactElement} and the correct ticket when picking
+ */
 const TicketPicker = (props: TicketPickerProps) => {
   const [ticketTypesState, setTicketTypesState] = useState<TicketPickerState>(initialState);
 

--- a/client/src/components/Ticketing/ticketingmanager/ticketing/ticketingSlice.spec.ts
+++ b/client/src/components/Ticketing/ticketingmanager/ticketing/ticketingSlice.spec.ts
@@ -191,7 +191,7 @@ describe('ticketing slice', () => {
     });
   });
 
-  describe('reduers', () => {
+  describe('reducers', () => {
     let init = ticketingInitState;
     it('addTicketReducer: new ticket', () => {
       const payload = {id: 1, tickettype: tickettype, qty: 2, concessions: false};

--- a/client/src/components/Ticketing/ticketingmanager/ticketing/ticketingSlice.spec.ts
+++ b/client/src/components/Ticketing/ticketingmanager/ticketing/ticketingSlice.spec.ts
@@ -119,7 +119,7 @@ describe('ticketing slice', () => {
       date: new Date('2021-08-08T16:00:00'),
       desc: 'desc1',
       product_img_url: 'www.com',
-      payWhatCan: false, 
+      payWhatCan: false,
       price: 2.99,
 
     };

--- a/client/src/components/Ticketing/ticketingmanager/ticketing/ticketingSlice.ts
+++ b/client/src/components/Ticketing/ticketingmanager/ticketing/ticketingSlice.ts
@@ -65,6 +65,7 @@ export interface Ticket {
 
 /**
  * TicketType Info
+ *
  * @module
  * @param {number} id
  * @param {string} name
@@ -289,6 +290,7 @@ const appendCartField = <T extends CartItem>(key: keyof T, val: T[typeof key]) =
  *
  * @module
  * @param data.ticket
+ * @param data.tickettype
  * @param data.event
  * @param data.qty
  * @param {Array} data - ticket, event, qty, CartItem


### PR DESCRIPTION
### Description
When building the client container, there would be several eslint warnings and a warning about a missing parameter in one ticketingSlice test. These have been resolved by adding the parameter and fixing the eslint spacing issues.

Also added `client/build` to the .gitignore as it houses temporary dev files we wouldn't want to commit to the GitHub repo.

### Risks
There is a possible risk with adding `client/build` to the .gitignore, but seeing as no build files currently exist in the repo, I don't feel as though they are necessary.

### Validation
Checked the docker client console before and after making the changes.

#### Before:
![image](https://github.com/WonderTix/WonderTix/assets/92124260/2d64be5c-41d0-4d05-920a-5e7f26670294)

#### After:
![image](https://github.com/WonderTix/WonderTix/assets/92124260/eb344710-4416-4bb1-84a5-4547990f33eb)

### Issue
Jira Ticket [TIC-38](https://pdx-hkaus.atlassian.net/browse/TIC-38).

### Operating System
Windows 11

[TIC-38]: https://pdx-hkaus.atlassian.net/browse/TIC-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ