### PR TITLE
[VSCode] Ignore Server Folder for Jest tests

### DIFF
--- a/WonderTix.code-workspace
+++ b/WonderTix.code-workspace
@@ -23,6 +23,7 @@
 			"WonderTix Client",
 			"WonderTix Root",
 			"WonderTix Deploy",
+			"WonderTix Server",
 		],
 	},
 }


### PR DESCRIPTION
### Description
Added the `./server/` folder to the WonderTix codespace file so VSCode stops complaining that jest is removed from the server and it can't find a valid jest project

### Risks
None, jest isn't used at the moment

### Validation
Opened the WonderTix workspace file in VSCode and saw no more complaining or issues

### Issue
N/A

### Operating System
macOS Sonoma (14.0), intel