### PR TITLE
[DON-91] fixed navbar profile image shrinkage

### DIFF
--- a/client/src/components/Ticketing/mainpage/Navbar.tsx
+++ b/client/src/components/Ticketing/mainpage/Navbar.tsx
@@ -107,7 +107,7 @@ const Navbar = ({bMode}: NavbarProps) => {
         <div className="w-1/2 hidden md:flex mr-4 gap-4">
           <div className="w-full flex items-center pl-8 justify-end">
             {login ? (
-              <div className="flex items-center relative cursor-pointer px-4" onClick={() => setProfile(!profile)}>
+              <div className="flex items-center relative cursor-pointer px-4 flex-shrink-0" onClick={() => setProfile(!profile)}>
                 <div className="rounded-full">
                   {profile ? (
                     <div>


### PR DESCRIPTION
### Description
On changing screen size, the profile picture of the main page navbar would shrink horizontally. The profile picture should stay the same until the layout snaps to mobile size. This small change fixes the issue.

Compressed profile picture before fix:
![image](https://github.com/WonderTix/WonderTix/assets/35203283/d93445d8-6ec4-4e4f-81c1-caed012de185)


### Risks
None

### Validation
Now as the screen gets smaller the profile image no longer appears to compress. This was tested on Google Chrome.

### Issue
[https://github.com/WonderTix/WonderTix/issues/241](https://github.com/WonderTix/WonderTix/issues/241)


### Operating System
Mac: Apple M1
