### PR TITLE
Disable eslint max-len rule and add prettier rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,9 +194,6 @@ web_modules/
 # Optional npm cache directory
 .npm
 
-# Optional prettier configuration file
-.prettierrc
-
 # Optional eslint cache
 .eslintcache
 
@@ -720,9 +717,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
-
-# Local History for Visual Studio Code
-.history
 
 # Windows Installer files from build outputs
 

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -25,6 +25,7 @@
     ],
     "rules": {
         "no-unused-vars": "off",
+        "max-len": "off",
         "linebreak-style": 0,
         "valid-jsdoc": "off",
 

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -24,13 +24,13 @@
         "@typescript-eslint"
     ],
     "rules": {
-        "no-unused-vars": "off",
-        "max-len": "off",
+        "camelcase": "off",
         "linebreak-style": 0,
+        "max-len": "off",
+        "no-unused-vars": "off",
         "valid-jsdoc": "off",
 
         "@typescript-eslint/no-unused-vars": "off",
-        "camelcase": "off",
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-non-null-assertion": "off",

--- a/client/.prettierrc
+++ b/client/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "bracketSpacing": false
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -59,9 +59,7 @@
         "cross-env": "^7.0.3",
         "eslint": "^8.27.0",
         "eslint-config-google": "^0.14.0",
-        "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-jsdoc": "^39.6.2",
-        "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-react": "^7.30.0",
         "tailwindcss": "^3.1.4"
       },
@@ -8226,18 +8224,6 @@
         "eslint": ">=5.16.0"
       }
     },
-    "node_modules/eslint-config-prettier": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
-      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
-      "dev": true,
-      "bin": {
-        "eslint-config-prettier": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
-      }
-    },
     "node_modules/eslint-config-react-app": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz",
@@ -8528,35 +8514,6 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
-      }
-    },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
-      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
-      "dev": true,
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.8.5"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/prettier"
-      },
-      "peerDependencies": {
-        "@types/eslint": ">=8.0.0",
-        "eslint": ">=8.0.0",
-        "prettier": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/eslint": {
-          "optional": true
-        },
-        "eslint-config-prettier": {
-          "optional": true
-        }
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -9124,12 +9081,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "node_modules/fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -15780,34 +15731,6 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
-      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-bytes": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -59,7 +59,9 @@
         "cross-env": "^7.0.3",
         "eslint": "^8.27.0",
         "eslint-config-google": "^0.14.0",
+        "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-jsdoc": "^39.6.2",
+        "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-react": "^7.30.0",
         "tailwindcss": "^3.1.4"
       },
@@ -8224,6 +8226,18 @@
         "eslint": ">=5.16.0"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-config-react-app": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz",
@@ -8514,6 +8528,35 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -9081,6 +9124,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -15731,6 +15780,34 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-bytes": {

--- a/client/package.json
+++ b/client/package.json
@@ -85,9 +85,7 @@
     "cross-env": "^7.0.3",
     "eslint": "^8.27.0",
     "eslint-config-google": "^0.14.0",
-    "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-jsdoc": "^39.6.2",
-    "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.30.0",
     "tailwindcss": "^3.1.4"
   }

--- a/client/package.json
+++ b/client/package.json
@@ -85,7 +85,9 @@
     "cross-env": "^7.0.3",
     "eslint": "^8.27.0",
     "eslint-config-google": "^0.14.0",
+    "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-jsdoc": "^39.6.2",
+    "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.30.0",
     "tailwindcss": "^3.1.4"
   }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable max-len */
-/* eslint-disable no-unused-vars */
-
 /* CRM */
 import React from 'react';
 import {Routes, Route} from 'react-router-dom';

--- a/client/src/components/CRM/Accounts/AccountsDash.tsx
+++ b/client/src/components/CRM/Accounts/AccountsDash.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable react/react-in-jsx-scope */
 // import React from 'react';
 // import Login from './Login';

--- a/client/src/components/CRM/Accounts/ManageUsers/ManageAccounts.tsx
+++ b/client/src/components/CRM/Accounts/ManageUsers/ManageAccounts.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/CRM/Accounts/ManageUsers/ManageAccountsmain.tsx
+++ b/client/src/components/CRM/Accounts/ManageUsers/ManageAccountsmain.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import React from 'react';
 import ManageAccounts from './ManageAccounts';
 import Navigation from '../../Navigation';

--- a/client/src/components/CRM/Accounts/SearchAccount/Accounts.tsx
+++ b/client/src/components/CRM/Accounts/SearchAccount/Accounts.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React, {useEffect, useState} from 'react';
 import axios from 'axios';
 import {useNavigate, useParams} from 'react-router-dom';
@@ -86,7 +85,6 @@ const Accounts = (): React.ReactElement => {
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd"
-              // eslint-disable-next-line max-len
                 d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" />
             </svg>
           </button>

--- a/client/src/components/CRM/Contacts/ContactOneResult.tsx
+++ b/client/src/components/CRM/Contacts/ContactOneResult.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable max-len */
 /* eslint-disable require-jsdoc */
 
 import React, {ReactElement, useEffect, useState} from 'react';

--- a/client/src/components/CRM/Contacts/ContactResults.tsx
+++ b/client/src/components/CRM/Contacts/ContactResults.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable max-len */
 /* eslint-disable require-jsdoc */
 
 import React from 'react';

--- a/client/src/components/CRM/Contacts/Contacts.tsx
+++ b/client/src/components/CRM/Contacts/Contacts.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React, {useEffect, useState} from 'react';
 import axios from 'axios';
 import {useNavigate, useParams} from 'react-router-dom';
@@ -84,7 +83,6 @@ const Contacts = (): React.ReactElement => {
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd"
-              // eslint-disable-next-line max-len
                 d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" />
             </svg>
           </button>

--- a/client/src/components/CRM/Dashboard.tsx
+++ b/client/src/components/CRM/Dashboard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from 'react';
 import {useNavigate} from 'react-router-dom';
 /**

--- a/client/src/components/CRM/Home.tsx
+++ b/client/src/components/CRM/Home.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from 'react';
 import {useAuth0} from '@auth0/auth0-react';
 import AuthNav from '../Authentication/auth-nav';

--- a/client/src/components/CRM/Navigation.tsx
+++ b/client/src/components/CRM/Navigation.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable operator-linebreak */
-/* eslint-disable max-len */
 import React, {useState} from 'react';
 import logo from '../../Logo/2011_Logo_white.png';
 import '../../Logo/logo.css';

--- a/client/src/components/CRM/Reporting/Reporting.tsx
+++ b/client/src/components/CRM/Reporting/Reporting.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 // Bug description: Unable to display column headers with full user information,
 // When moving the scroll bar to the right, everything goes back to normal.
 import React from 'react';
@@ -105,7 +104,6 @@ const ReportingTest = (): React.ReactElement => {
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round"
-              // eslint-disable-next-line max-len
               d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10" />
           </svg>
           Export

--- a/client/src/components/CRM/Tasks/Search.tsx
+++ b/client/src/components/CRM/Tasks/Search.tsx
@@ -79,7 +79,6 @@ const SearchBar = (props: any): React.ReactElement => {
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" viewBox="0 0 20 20" fill="currentColor">
             <path fillRule="evenodd"
-              // eslint-disable-next-line max-len
               d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" />
           </svg>
         </button>

--- a/client/src/components/Ticketing/Pop-up.tsx
+++ b/client/src/components/Ticketing/Pop-up.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React, {CSSProperties} from 'react';
 import popupProps from '../../interfaces/popup.interface';
 

--- a/client/src/components/Ticketing/cart/Cart.tsx
+++ b/client/src/components/Ticketing/cart/Cart.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React, {useEffect, useState} from 'react';
 import {useAppSelector, useAppDispatch} from '../app/hooks';
 import CartRow from './CartItem';

--- a/client/src/components/Ticketing/cart/CartItem.tsx
+++ b/client/src/components/Ticketing/cart/CartItem.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/cart/YourOrder.tsx
+++ b/client/src/components/Ticketing/cart/YourOrder.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/checkout/CheckoutPage.tsx
+++ b/client/src/components/Ticketing/checkout/CheckoutPage.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/react-in-jsx-scope */
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/checkout/CheckoutSuccess.tsx
+++ b/client/src/components/Ticketing/checkout/CheckoutSuccess.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/checkout/CompleteOrderForm.tsx
+++ b/client/src/components/Ticketing/checkout/CompleteOrderForm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *
@@ -76,7 +75,6 @@ function validateEmail(email: string) {
  * @returns {ReactElement}
  */
 export default function CompleteOrderForm(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     {onSubmit, onBack, disabled, donationForm}: CompleteOrderFormProps,
 ): ReactElement {
   const [firstName, setfirstName] = useState('');
@@ -114,7 +112,6 @@ export default function CompleteOrderForm(
         <Form
           onSubmit={handleSubmit}
           initialValues={{'opt-in': false, 'seating-accommodation': false}}
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           render={({handleSubmit}) => (
             <form onSubmit={handleSubmit} noValidate className='w-full h-full bg-zinc-200 p-9 rounded-xl flex flex-col  justify-between'>
               <div className='flex flex-col w-full  '>

--- a/client/src/components/Ticketing/donation/DonationPage.tsx
+++ b/client/src/components/Ticketing/donation/DonationPage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/donation/OnlyDonatePage.tsx
+++ b/client/src/components/Ticketing/donation/OnlyDonatePage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/event/EventInstanceSelect.tsx
+++ b/client/src/components/Ticketing/event/EventInstanceSelect.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/event/TicketPicker.tsx
+++ b/client/src/components/Ticketing/event/TicketPicker.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright Â© 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/event/eventshowings.tsx
+++ b/client/src/components/Ticketing/event/eventshowings.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React, {useEffect, useState} from 'react';
 import {useAppSelector, useAppDispatch} from '../app/hooks';
 import {useParams} from 'react-router-dom';
@@ -60,7 +59,6 @@ const Eventshowings = () => {
   const eventData = useAppSelector((state) => selectEventData(state, eventid));
   if (eventData === undefined) return <p>Whoops! Event not found</p>;
   const {title, description, tickets} = eventData;
-  // eslint-disable-next-line camelcase
   const imageUrl = eventData.imageurl;
   return (
     <div className = ' w-full h-screen  ' >

--- a/client/src/components/Ticketing/mainpage/Navbar.tsx
+++ b/client/src/components/Ticketing/mainpage/Navbar.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-len */
-/* eslint-disable no-unused-vars */
 import React, {useState, useEffect} from 'react';
 import {MenuIcon, XIcon} from '@heroicons/react/outline';
 import {useNavigate} from 'react-router-dom';

--- a/client/src/components/Ticketing/mainpage/Navbar.tsx
+++ b/client/src/components/Ticketing/mainpage/Navbar.tsx
@@ -107,7 +107,7 @@ const Navbar = ({bMode}: NavbarProps) => {
         <div className="w-1/2 hidden md:flex mr-4 gap-4">
           <div className="w-full flex items-center pl-8 justify-end">
             {login ? (
-              <div className="flex items-center relative cursor-pointer px-4" onClick={() => setProfile(!profile)}>
+              <div className="flex items-center relative cursor-pointer px-4 flex-shrink-0" onClick={() => setProfile(!profile)}>
                 <div className="rounded-full">
                   {profile ? (
                     <div>

--- a/client/src/components/Ticketing/mainpage/PageNotFound.tsx
+++ b/client/src/components/Ticketing/mainpage/PageNotFound.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-len */
-
 import React from 'react';
 import Navbar from './Navbar';
 import {useNavigate} from 'react-router';

--- a/client/src/components/Ticketing/mainpage/Seasonalt.tsx
+++ b/client/src/components/Ticketing/mainpage/Seasonalt.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from 'react';
 
 /**

--- a/client/src/components/Ticketing/mainpage/hero.tsx
+++ b/client/src/components/Ticketing/mainpage/hero.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React, {useEffect} from 'react';
 import {ListComponent} from './eventcard';
 import {useAppSelector, useAppDispatch} from '../app/hooks';

--- a/client/src/components/Ticketing/ticketingmanager/AdminNavDropdown.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/AdminNavDropdown.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-len */
-/* eslint-disable camelcase */
 import React, {useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 import {useAuth0} from '@auth0/auth0-react';

--- a/client/src/components/Ticketing/ticketingmanager/Doorlistpage/doorlist.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Doorlistpage/doorlist.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/ticketingmanager/Doorlistpage/doorlistmain.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Doorlistpage/doorlistmain.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import React from 'react';
 import Udash_nav from '../udash_navbar';
 import DoorList from './doorlist';

--- a/client/src/components/Ticketing/ticketingmanager/Events/Add_event/CreateEventPage.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/Add_event/CreateEventPage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/ticketingmanager/Events/Add_event/addevent.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/Add_event/addevent.tsx
@@ -1,6 +1,4 @@
 /* eslint-disable require-jsdoc */
-/* eslint-disable no-unused-vars */
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/ticketingmanager/Events/Add_event/addeventmain.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/Add_event/addeventmain.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import React from 'react';
 import Udash_nav from '../../udash_navbar';
 // import CreateEvents from './addevent';

--- a/client/src/components/Ticketing/ticketingmanager/Events/Delete_event/Deleteevent.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/Delete_event/Deleteevent.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable require-jsdoc */
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/ticketingmanager/Events/Delete_event/Deleteventmain.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/Delete_event/Deleteventmain.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import React from 'react';
 import Udash_nav from '../../udash_navbar';
 import DeleteEvents from './Deleteevent';

--- a/client/src/components/Ticketing/ticketingmanager/Events/Edit_event/EditEventPage.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/Edit_event/EditEventPage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/ticketingmanager/Events/Edit_event/Editeventmain.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/Edit_event/Editeventmain.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase*/
-/* eslint-disable max-len */
 import React, {useEffect, useState} from 'react';
 import Udash_nav from '../../udash_navbar';
 import EditEventPage from './EditEventPage';

--- a/client/src/components/Ticketing/ticketingmanager/Events/EventForm.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/EventForm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *
@@ -105,7 +104,6 @@ interface EventFormProps {
  * @param eventname.initialValues
  * @returns {Form} EventForm
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const EventForm = ({onSubmit, tickettypes, initialValues}: EventFormProps) => {
   const def: WtixEvent = (initialValues !== undefined) ? {
     eventname: initialValues.eventname,

--- a/client/src/components/Ticketing/ticketingmanager/Events/deleteConfirm.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/deleteConfirm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React, {CSSProperties} from 'react';
 import popupProps from '../../../../interfaces/popup.interface';
 

--- a/client/src/components/Ticketing/ticketingmanager/Events/events_pages/eventsSlice.spec.ts
+++ b/client/src/components/Ticketing/ticketingmanager/Events/events_pages/eventsSlice.spec.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/ticketingmanager/Events/events_pages/eventsSlice.ts
+++ b/client/src/components/Ticketing/ticketingmanager/Events/events_pages/eventsSlice.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-len */
-/* eslint-disable camelcase */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/ticketingmanager/Events/showListController.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/showListController.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable require-jsdoc */
-/* eslint-disable max-len */
 import React, {useState, useCallback, useEffect} from 'react';
 import {Showing} from '../../../../interfaces/showing.interface';
 // import EventForm from './EventForm';

--- a/client/src/components/Ticketing/ticketingmanager/Events/showingInputContainer.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Events/showingInputContainer.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React, {useEffect, useState} from 'react';
 import {Showing} from '../../../../interfaces/showing.interface';
 import DeleteConfirm from './deleteConfirm';

--- a/client/src/components/Ticketing/ticketingmanager/Newsletter/NewsletterCreate.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Newsletter/NewsletterCreate.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/ticketingmanager/Newsletter/NewsletterCreatemain.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Newsletter/NewsletterCreatemain.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import React from 'react';
 import Udash_nav from '../udash_navbar';
 import NewsletterCreate from './NewsletterCreate';

--- a/client/src/components/Ticketing/ticketingmanager/TicketExchanges/TicketExchangesmain.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/TicketExchanges/TicketExchangesmain.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import React from 'react';
 import Udash_nav from '../udash_navbar';
 import TicketExchanges from './TicketExchanges';

--- a/client/src/components/Ticketing/ticketingmanager/TicketTypes/tickettypes.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/TicketTypes/tickettypes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React, {useEffect, useState} from 'react';
 import {
   DataGrid,

--- a/client/src/components/Ticketing/ticketingmanager/TicketTypes/tickettypesmain.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/TicketTypes/tickettypesmain.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import React from 'react';
 import Udash_nav from '../udash_navbar';
 import TicketTypes from './tickettypes';

--- a/client/src/components/Ticketing/ticketingmanager/Udashmain.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Udashmain.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import React from 'react';
 import Dashboard from './dashboard';
 import Udash_nav from './udash_navbar';

--- a/client/src/components/Ticketing/ticketingmanager/dashboard.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/dashboard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from 'react';
 import {useNavigate} from 'react-router-dom';
 

--- a/client/src/components/Ticketing/ticketingmanager/donationSlice.ts
+++ b/client/src/components/Ticketing/ticketingmanager/donationSlice.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/ticketingmanager/showings/InstancesPage.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/showings/InstancesPage.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable max-len */
 /* eslint-disable require-jsdoc */
 /* eslint-disable react/react-in-jsx-scope */
 /**

--- a/client/src/components/Ticketing/ticketingmanager/showings/Showingsmain.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/showings/Showingsmain.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import React from 'react';
 import Udash_nav from '../udash_navbar';
 import InstancesPage from './InstancesPage';

--- a/client/src/components/Ticketing/ticketingmanager/showings/showing/showing.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/showings/showing/showing.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-/* eslint-disable max-len */
 import React, {useEffect, useState} from 'react';
 import {useParams} from 'react-router-dom';
 import {titleCase} from '../../../../../utils/arrays';

--- a/client/src/components/Ticketing/ticketingmanager/showings/showing/showingmain.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/showings/showing/showingmain.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import React from 'react';
 import Udash_nav from '../../udash_navbar';
 import Showing from './showing';

--- a/client/src/components/Ticketing/ticketingmanager/snackbarSlice.ts
+++ b/client/src/components/Ticketing/ticketingmanager/snackbarSlice.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/ticketingmanager/ticketing/ticketingSlice.spec.ts
+++ b/client/src/components/Ticketing/ticketingmanager/ticketing/ticketingSlice.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/ticketingmanager/ticketing/ticketingSlice.ts
+++ b/client/src/components/Ticketing/ticketingmanager/ticketing/ticketingSlice.ts
@@ -1,6 +1,3 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable camelcase */
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/components/Ticketing/ticketingmanager/udash_navbar.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/udash_navbar.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable operator-linebreak */
-/* eslint-disable camelcase */
 import React, {useState} from 'react';
 import logoi from '../../../assets/pp_logo_white.png';
 import {useNavigate} from 'react-router-dom';

--- a/client/src/components/Ticketing/ticketingmanager/udash_navbar.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/udash_navbar.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable operator-linebreak */
-/* eslint-disable max-len */
 /* eslint-disable camelcase */
 import React, {useState} from 'react';
 import logoi from '../../../assets/pp_logo_white.png';

--- a/client/src/components/Ticketing/userdashboard/udash_navbar.tsx
+++ b/client/src/components/Ticketing/userdashboard/udash_navbar.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-len */
-/* eslint-disable camelcase */
 import React, {useState} from 'react';
 import logoi from '../../../assets/pp_logo_white.png';
 import {useNavigate} from 'react-router-dom';

--- a/client/src/react-app-env.d.ts
+++ b/client/src/react-app-env.d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Copyright © 2021 Aditya Sharoff, Gregory Hairfeld, Jesse Coyle, Francis Phan, William Papsco, Jack Sherman, Geoffrey Corvera
  *

--- a/client/src/utils/arrays.tsx
+++ b/client/src/utils/arrays.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /*
 export const anchors = [
   { title: "Accounts", link: "/accounts" },

--- a/server/src/api/events/event.service.ts
+++ b/server/src/api/events/event.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import {query} from 'express';
 import {link} from 'fs';
 import Delta from '../../interfaces/Delta';


### PR DESCRIPTION
### Description
* Disabled eslint `max-len` rule.
* Added `.prettierrc` file that aligns with eslint rules
* Removed duplicate `.history` from `.gitignore`

### Risks

### Validation
Tested on multiple computers. When merged, nothing related to prettier is forced on a dev.

### Issue
N/A

### Operating System
Windows 11