### PR TITLE
Add Timeouts to E2E Tests

### DIFF
--- a/client/tests/example.spec.ts
+++ b/client/tests/example.spec.ts
@@ -1,50 +1,56 @@
-import { test, expect } from '@playwright/test';
+import {test, expect} from '@playwright/test';
 
-test('has title', async ({ page }) => {
+test('has title', async ({page}) => {
   await page.goto('https://playwright.dev/');
 
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle(/Playwright/);
 });
 
-test('get started link', async ({ page }) => {
+test('get started link', async ({page}) => {
   await page.goto('https://playwright.dev/');
 
   // Click the get started link.
-  await page.getByRole('link', { name: 'Get started' }).click();
+  await page.getByRole('link', {name: 'Get started'}).click();
 
   // Expects the URL to contain intro.
   await expect(page).toHaveURL(/.*intro/);
 });
 
-test('portland play house link',async({page})=>{
+test('portland play house link', async ({page})=>{
+  // Timeout for client to load
+  test.setTimeout(100000);
+
   await page.goto('https://localhost:3000/');
 
-  await page.getByRole('link', { name: '/' }).click();
+  await page.getByRole('link', {name: '/'}).click();
 
   await expect(page).toHaveURL('https://portlandplayhouse.org/');
 });
 
-test('donate',async({page})=>{
+test('donate', async ({page})=>{
   await page.goto('https://localhost:3000/');
 
-  await page.getByRole('button', { name: 'Donate' }).click();
+  await page.getByRole('button', {name: 'Donate'}).click();
 
   await expect(page).toHaveURL('https://localhost:3000/donate');
 
-  await page.getByRole('button', { name: 'Back to Events' }).click();
+  await page.getByRole('button', {name: 'Back to Events'}).click();
 
   await expect(page).toHaveURL('https://localhost:3000/');
 });
 
-test('events',async({page})=>{
+test('events', async ({page})=>{
+  // Timeout for server to load
+  test.setTimeout(120000);
+
   await page.goto('https://localhost:3000/');
 
-  await page.getByRole('button', { name: 'See Showings' }).first().click();
+  await page.getByRole('button', {name: 'See Showings'}).first().click();
 
   await expect(page).toHaveURL('https://localhost:3000/events/32');
 
-  await page.getByRole('button', { name: 'Back to Events' }).click();
+  await page.getByRole('button', {name: 'Back to Events'}).click();
 
   await expect(page).toHaveURL('https://localhost:3000/');
 });


### PR DESCRIPTION
### Description
Added 100s timeout for client and and 120s timeout for server to load and fixed eslint spacing issues in test file.

### Risks
N/A

### Validation
This PR passes with flying colors.

### Issue
N/A

### Operating System
N/A (GitHub Actions)