### PR TITLE
DEP: switch hard-coded GCP project number in cloudbuild.yaml

### DIFF
--- a/client/cloudbuild.yaml
+++ b/client/cloudbuild.yaml
@@ -46,8 +46,8 @@ steps:
 
 availableSecrets:
   secretManager:
-  - versionName: projects/144838889706/secrets/AUTH0_CLIENT_ID/versions/latest
+  - versionName: projects/131818279954/secrets/AUTH0_CLIENT_ID/versions/latest
     env: 'REACT_APP_AUTH0_CLIENT_ID'
-  - versionName: projects/144838889706/secrets/PUBLIC_STRIPE_KEY_DEV/versions/latest
+  - versionName: projects/131818279954/secrets/PUBLIC_STRIPE_KEY_DEV/versions/latest
     env: 'REACT_APP_PUBLIC_STRIPE_KEY'
 


### PR DESCRIPTION
Change hard-coded value in `cloudbuild.yaml` in order to migrate to new GCP project.