### PR TITLE
TIC-77: Update swagger page and fix api for seasons

### DIFF
--- a/server/prisma/migrations/20231012025406_change_event_season_i_dfk_constraint/migration.sql
+++ b/server/prisma/migrations/20231012025406_change_event_season_i_dfk_constraint/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "events" DROP CONSTRAINT "events_seasonid_fkey";
+
+-- AlterTable
+ALTER TABLE "events" ALTER COLUMN "seasonid_fk" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "events" ADD CONSTRAINT "events_seasonid_fkey" FOREIGN KEY ("seasonid_fk") REFERENCES "seasons"("seasonid") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -125,14 +125,14 @@ model eventinstances {
 /// the showings of an event are eventinstances
 model events {
   eventid              Int              @id @default(autoincrement())
-  seasonid_fk          Int
+  seasonid_fk          Int?
   eventname            String           @db.VarChar(255)
   eventdescription     String?          @db.VarChar(255)
   active               Boolean?
   seasonticketeligible Boolean?
   imageurl             String?          @db.VarChar(255)
   eventinstances       eventinstances[]
-  seasons              seasons          @relation(fields: [seasonid_fk], references: [seasonid], onDelete: NoAction, onUpdate: NoAction, map: "events_seasonid_fkey")
+  seasons              seasons?          @relation(fields: [seasonid_fk], references: [seasonid], onDelete: SetNull, onUpdate: Cascade, map: "events_seasonid_fkey")
   seasontickets        seasontickets[]
 }
 

--- a/server/src/controllers/seasonController.ts
+++ b/server/src/controllers/seasonController.ts
@@ -46,6 +46,7 @@ seasonController.post('/', async (req: Request, res: Response) => {
         name: req.body.name,
         startdate: req.body.startdate,
         enddate: req.body.enddate,
+        imageurl: req.body.imageurl,
       },
     });
     res.status(201).json(season);
@@ -240,7 +241,7 @@ seasonController.get('/:id', async (req: Request, res: Response) => {
 seasonController.put('/:id', async (req: Request, res: Response) => {
   try {
     const id = req.params.id;
-    const season = prisma.seasons.update({
+    const season = await prisma.seasons.update({
       where: {
         seasonid: Number(id),
       },
@@ -248,6 +249,7 @@ seasonController.put('/:id', async (req: Request, res: Response) => {
         name: req.body.name,
         startdate: req.body.startdate,
         enddate: req.body.enddate,
+        imageurl: req.body.imageurl,
       },
     });
     res.status(204).json();
@@ -308,7 +310,7 @@ seasonController.delete('/:id', async (req: Request, res: Response) => {
 
       return;
     }
-    const season = prisma.seasons.delete({
+    const season = await prisma.seasons.delete({
       where: {
         seasonid: Number(id),
       },

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -581,9 +581,6 @@ const createServer = async () => {
 
   let server;
 
-  console.log('process.env');
-  console.log(process.env);
-
   if (process.env.ENV === 'local') {
     const privateKey = fs.readFileSync('localhost-key.pem', 'utf8');
     const certificate = fs.readFileSync('localhost.pem', 'utf8');

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -207,6 +207,7 @@ const openApiSpec = swaggerJsdoc({
             name: {type: 'string'},
             startdate: {type: 'integer'},
             enddate: {type: 'integer'},
+            imageurl: {type: 'string'},
           },
         },
         SeasonTicket: {
@@ -417,6 +418,7 @@ const openApiSpec = swaggerJsdoc({
             name: {type: 'string'},
             startdate: {type: 'integer'},
             enddate: {type: 'integer'},
+            imageurl: {type: 'string'},
           },
         },
         SeasonTicket: {
@@ -510,20 +512,14 @@ const openApiSpec = swaggerJsdoc({
 const createServer = async () => {
   let envPath;
   if (process.env.ENV === 'local') {
-      envPath = path.join(__dirname, '../../.env');
-      // console.log("local")
-      // console.log(process.env)
+    envPath = path.join(__dirname, '../../.env');
   } else if (process.env.ENV === 'dev') {
-      envPath = path.join(__dirname, '../.env');
-      // console.log("dev")
-      // console.log(process.env)
+    envPath = path.join(__dirname, '../.env');
   } else {
-      throw new Error('Unknown ENV value');
+    throw new Error('Unknown ENV value');
   }
-  // console.log('process.env in server.ts');
-  // console.log(process.env);
 
-  dotenv.config({ path: envPath });
+  dotenv.config({path: envPath});
 
 
   const app = express();
@@ -585,20 +581,19 @@ const createServer = async () => {
 
   let server;
 
-  console.log("process.env")
-  console.log(process.env)
+  console.log('process.env');
+  console.log(process.env);
 
   if (process.env.ENV === 'local') {
     const privateKey = fs.readFileSync('localhost-key.pem', 'utf8');
     const certificate = fs.readFileSync('localhost.pem', 'utf8');
-    const credentials = { key: privateKey, cert: certificate };
+    const credentials = {key: privateKey, cert: certificate};
     server = https.createServer(credentials, app);
   } else {
     server = http.createServer(app);
   }
-  
-  return server; 
 
+  return server;
 };
 
 createServer().then((server) => {


### PR DESCRIPTION
### Description
- Updated the OpenAPI specification for the seasons swagger page API endpoint to include the new imageurl data column that was added. Specifically for the endpoints getSeason, getAllSeason, and updateSeason.
- Fixed the deleteSeason endpoint because previously, we could not delete a season since there are events that reference it. I ran a database migration to make the seasonID foreign key of the Events table optional so that we can now delete seasons even when there are events that reference them. This change will make the seasonID column for events NULL if a season that it references is deleted.

### Risks
Very minimal, although DB migrations always run the risk of having unseen consequences. However, considering  season was never utilized to begin, the migration shouldn't have any negative effects.

### Validation
Tested every API endpoint for seasons to ensure it does what it needs to do. Double checked the results in both pgAdmin and the swagger page.

### Issue
https://pdx-hkaus.atlassian.net/jira/software/projects/TIC/boards/1?selectedIssue=TIC-103

### Operating System
M2 Macbook
