### PR TITLE
[DEP-57] E2E tests after merge to main

### DIFF
--- a/.github/workflows/E2E_deployment.yml
+++ b/.github/workflows/E2E_deployment.yml
@@ -1,7 +1,8 @@
 name: E2E tests after merge to main deployment
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review, edited, synchronize]
+  push:
+    branches:
+      - main
 
 jobs:
   test-client:

--- a/.github/workflows/E2E_deployment.yml
+++ b/.github/workflows/E2E_deployment.yml
@@ -1,0 +1,88 @@
+name: E2E tests after merge to main deployment
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, edited, synchronize]
+
+jobs:
+  test-client:
+    name: Run E2E tests against GCP dev
+    runs-on: ubuntu-latest
+    env:
+      CI: true # SET CI TO TRUE FOR GITHUB ACTIONS
+      PG_USER: postgres
+      PG_PASS: postgres
+      PG_DB: wondertix
+      PG_PORT: 5432
+      PG_HOST: 172.17.0.1
+      PUBLIC_STRIPE_KEY: ${{ secrets.PUBLIC_STRIPE_KEY }}
+      PRIVATE_STRIPE_KEY: ${{ secrets.PRIVATE_STRIPE_KEY }}
+      PRIVATE_STRIPE_WEBHOOK: ${{ secrets.PRIVATE_STRIPE_WEBHOOK }}
+      ROOT_URL: https://wondertix-server-3ps4rkx4ga-wl.a.run.app
+      FRONTEND_URL: https://wondertix-client-3ps4rkx4ga-wl.a.run.app
+      AUTH0_AUDIENCE: ${{ secrets.AUTH0_AUDIENCE }}
+      AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+      AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
+      AUTH0_URL: ${{ secrets.AUTH0_URL }}
+      TEST_EMAIL: ${{ secrets.TEST_EMAIL }} 
+      TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }} 
+      ENV: local
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          cache: 'npm'
+          cache-dependency-path: ./client/package-lock.json
+      
+      - name: npm install
+        run: npm install --force
+        working-directory: ./client
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: 5 minutes wait for deployment
+        run: sleep 300s
+        
+      - name: Check client E2E(UI) Tests
+        run: npm run test:playwright
+        # run: DEBUG=pw:api npx playwright test
+        working-directory: ./client
+      
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: ./client/playwright
+          retention-days: 30
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-results
+          path: ./client/test-results
+          retention-days: 30
+
+  # test-server:
+  #   name: Run Tests on server
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     AUTH0_AUDIENCE: ${{ secrets.AUTH0_AUDIENCE }}
+  #     AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+  #     AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
+  #     AUTH0_URL: ${{ secrets.AUTH0_URL }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Setup node
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version: '18.x'
+  #         cache: 'npm'
+  #         cache-dependency-path: ./client/package-lock.json
+  #     - name: npm install
+  #       run: npm install
+  #       working-directory: ./server
+
+  #     - name: Check Unit Tests
+  #       run: npm test
+  #       working-directory: ./server


### PR DESCRIPTION
### Description
E2E tests after merge to main
Create a Github Action via workflow.yaml, it will trigger playwright to run e2e tests against the specified GCP dev client URL with a 5 minute wait prior to running. 

### Risks
Test will run after a merge to main regardless of dev deployment success or failure. Will be iterating on this. 

### Validation
E2E tests have been verified to run but not from a merge to main. Merging to main to test. 

### Issue
[DEP-57]

### Operating System
Windows

[DEP-57]: https://wondertix.atlassian.net/browse/DEP-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ