### PR TITLE
DEP-75: set up `prd` environment

### DIFF
--- a/client/cloudbuild.yaml
+++ b/client/cloudbuild.yaml
@@ -44,6 +44,7 @@ steps:
         --region $$REGION \
         --platform managed \
         --memory $$CLIENT_MEMORY \
+        --cpu $$CLIENT_CPU \
         --allow-unauthenticated \
         --min-instances 1 \
         --set-env-vars=\
@@ -53,6 +54,7 @@ steps:
         REACT_APP_PUBLIC_STRIPE_KEY=REACT_APP_PUBLIC_STRIPE_KEY:$$ENV,\
     secretEnv:
       - 'ARTIFACTS'
+      - 'CLIENT_CPU'
       - 'CLIENT_MEMORY'
       - 'ENV'
       - 'REGION'
@@ -65,6 +67,8 @@ availableSecrets:
     env: 'ARTIFACTS'
   - versionName: projects/$PROJECT_ID/secrets/AUTH0_CLIENT_SECRET/versions/$_ENV
     env: 'AUTH0_CLIENT_SECRET'
+  - versionName: projects/$PROJECT_ID/secrets/CLIENT_CPU/versions/$_ENV
+    env: 'CLIENT_CPU'
   - versionName: projects/$PROJECT_ID/secrets/CLIENT_MEMORY/versions/$_ENV
     env: 'CLIENT_MEMORY'
   - versionName: projects/$PROJECT_ID/secrets/ENV/versions/$_ENV

--- a/client/cloudbuild.yaml
+++ b/client/cloudbuild.yaml
@@ -43,26 +43,30 @@ steps:
         --image $$ARTIFACTS/client-img-$$ENV \
         --region $$REGION \
         --platform managed \
-        --memory 2Gi \
+        --memory $$CLIENT_MEMORY \
         --allow-unauthenticated \
         --min-instances 1 \
+        --set-env-vars=\
+        ENV=$$ENV, \
         --set-secrets=\
-        ENV=ENV:$$ENV,\
         REACT_APP_AUTH0_CLIENT_ID=REACT_APP_AUTH0_CLIENT_ID:$$ENV,\
         REACT_APP_PUBLIC_STRIPE_KEY=REACT_APP_PUBLIC_STRIPE_KEY:$$ENV,\
     secretEnv:
       - 'ARTIFACTS'
+      - 'CLIENT_MEMORY'
       - 'ENV'
       - 'REGION'
       - 'SERVICE_ACCOUNT'
 
-# Use dev or stg versions depending on _ENV value from trigger
+# Use dev, stg, or prd versions depending on _ENV value from trigger
 availableSecrets:
   secretManager:
   - versionName: projects/$PROJECT_ID/secrets/ARTIFACTS/versions/$_ENV
     env: 'ARTIFACTS'
   - versionName: projects/$PROJECT_ID/secrets/AUTH0_CLIENT_SECRET/versions/$_ENV
     env: 'AUTH0_CLIENT_SECRET'
+  - versionName: projects/$PROJECT_ID/secrets/CLIENT_MEMORY/versions/$_ENV
+    env: 'CLIENT_MEMORY'
   - versionName: projects/$PROJECT_ID/secrets/ENV/versions/$_ENV
     env: 'ENV'
   - versionName: projects/$PROJECT_ID/secrets/REACT_APP_API_1_URL/versions/$_ENV
@@ -83,4 +87,3 @@ availableSecrets:
     env: 'REGION'
   - versionName: projects/$PROJECT_ID/secrets/SERVICE_ACCOUNT/versions/$_ENV
     env: 'SERVICE_ACCOUNT'
-

--- a/server/cloudbuild.yaml
+++ b/server/cloudbuild.yaml
@@ -22,15 +22,17 @@ steps:
         --image $$ARTIFACTS/server-img-$$ENV \
         --region $$REGION \
         --platform managed \
-        --memory 1Gi \
+        --memory $$SERVER_MEMORY \
         --allow-unauthenticated \
         --min-instances 1 \
         --set-cloudsql-instances $$SQL_INSTANCE \
         --service-account $$SERVICE_ACCOUNT \
         --set-env-vars=\
         AUTH0_AUDIENCE=$$AUTH0_AUDIENCE,\
+        AUTH0_URL=$$AUTH0_URL,\
+        ENV=$$ENV,\
         FRONTEND_URL=$$FRONTEND_URL,\
-        AUTH0_URL=$$AUTH0_URL, \
+        ROOT_URL=$$ROOT_URL, \
         --set-secrets=\
         AUTH0_CLIENT_SECRET=AUTH0_CLIENT_SECRET:$$ENV,\
         DATABASE_URL=DATABASE_URL:$$ENV,\
@@ -39,9 +41,7 @@ steps:
         DB_PASSWORD=DB_PASSWORD:$$ENV,\
         DB_PORT=DB_PORT:$$ENV,\
         DB_USER=DB_USER:$$ENV,\
-        ENV=ENV:$$ENV,\
         PRIVATE_STRIPE_KEY=PRIVATE_STRIPE_KEY:$$ENV,\
-        ROOT_URL=ROOT_URL:$$ENV,\
     secretEnv:
       - 'ARTIFACTS'
       - 'AUTH0_AUDIENCE'
@@ -50,10 +50,11 @@ steps:
       - 'FRONTEND_URL'
       - 'REGION'
       - 'ROOT_URL'
+      - 'SERVER_MEMORY'
       - 'SERVICE_ACCOUNT'
       - 'SQL_INSTANCE'
 
-# Use dev or stg versions depending on _ENV value from trigger
+# Use dev, stg, or prd versions depending on _ENV value from trigger
 availableSecrets:
   secretManager:
   - versionName: projects/$PROJECT_ID/secrets/ARTIFACTS/versions/$_ENV
@@ -70,8 +71,9 @@ availableSecrets:
     env: 'REGION'
   - versionName: projects/$PROJECT_ID/secrets/ROOT_URL/versions/$_ENV
     env: 'ROOT_URL'
+  - versionName: projects/$PROJECT_ID/secrets/SERVER_MEMORY/versions/$_ENV
+    env: 'SERVER_MEMORY'
   - versionName: projects/$PROJECT_ID/secrets/SERVICE_ACCOUNT/versions/$_ENV
     env: 'SERVICE_ACCOUNT'
   - versionName: projects/$PROJECT_ID/secrets/SQL_INSTANCE/versions/$_ENV
     env: 'SQL_INSTANCE'
-

--- a/server/cloudbuild.yaml
+++ b/server/cloudbuild.yaml
@@ -23,6 +23,7 @@ steps:
         --region $$REGION \
         --platform managed \
         --memory $$SERVER_MEMORY \
+        --cpu $$SERVER_CPU \
         --allow-unauthenticated \
         --min-instances 1 \
         --set-cloudsql-instances $$SQL_INSTANCE \
@@ -50,6 +51,7 @@ steps:
       - 'FRONTEND_URL'
       - 'REGION'
       - 'ROOT_URL'
+      - 'SERVER_CPU'
       - 'SERVER_MEMORY'
       - 'SERVICE_ACCOUNT'
       - 'SQL_INSTANCE'
@@ -71,6 +73,8 @@ availableSecrets:
     env: 'REGION'
   - versionName: projects/$PROJECT_ID/secrets/ROOT_URL/versions/$_ENV
     env: 'ROOT_URL'
+  - versionName: projects/$PROJECT_ID/secrets/SERVER_CPU/versions/$_ENV
+    env: 'SERVER_CPU'
   - versionName: projects/$PROJECT_ID/secrets/SERVER_MEMORY/versions/$_ENV
     env: 'SERVER_MEMORY'
   - versionName: projects/$PROJECT_ID/secrets/SERVICE_ACCOUNT/versions/$_ENV

--- a/server/src/api/db.ts
+++ b/server/src/api/db.ts
@@ -7,7 +7,7 @@ import {Pool, PoolConfig} from 'pg';
 let envPath;
 if (process.env.ENV === 'local') {
     envPath = path.join(__dirname, '../../../.env');
-} else if (process.env.ENV === 'dev' || process.env.ENV === 'stg') {
+} else if (process.env.ENV === 'dev' || process.env.ENV === 'stg' || process.env.ENV === 'prd') {
     envPath = path.join(__dirname, '../../.env');
 } else {
     throw new Error('Unknown ENV value');

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -510,7 +510,7 @@ const createServer = async () => {
   let envPath;
   if (process.env.ENV === 'local') {
     envPath = path.join(__dirname, '../../.env');
-  } else if (process.env.ENV === 'dev' || process.env.ENV === 'stg') {
+  } else if (process.env.ENV === 'dev' || process.env.ENV === 'stg' || process.env.ENV === 'prd') {
     envPath = path.join(__dirname, '../.env');
   } else {
     throw new Error('Unknown ENV value');


### PR DESCRIPTION
### Description
- Expands condition in server code to detect `ENV` value of `'prd'`.
- Parameterizes memory and CPU allocation in `cloudbuild.yaml`.

### Risks
- Bumping up resources allocated to `stg` and `prd` will increase cost.

### Validation
- Using this branch, I've deployed both client and server across `dev`, `stg`, and `prd` without issues.
- Client: https://wtix-client-prd-3ps4rkx4ga-wl.a.run.app/  
- Server: https://wtix-server-prd-3ps4rkx4ga-wl.a.run.app/

### Issue
- Link: [*DEP-75: Set up `prd` environment*](https://wondertix.atlassian.net/browse/DEP-75)

### Operating System
- Ubuntu 22.04
