### PR TITLE
DEP-77: explicitly set max value for Cloud Run autoscaling

### DIFF
--- a/client/cloudbuild.yaml
+++ b/client/cloudbuild.yaml
@@ -47,6 +47,7 @@ steps:
         --cpu $$CLIENT_CPU \
         --allow-unauthenticated \
         --min-instances 1 \
+        --max-instances 10 \
         --set-env-vars=\
         ENV=$$ENV, \
         --set-secrets=\

--- a/server/cloudbuild.yaml
+++ b/server/cloudbuild.yaml
@@ -26,6 +26,7 @@ steps:
         --cpu $$SERVER_CPU \
         --allow-unauthenticated \
         --min-instances 1 \
+        --max-instances 10 \
         --set-cloudsql-instances $$SQL_INSTANCE \
         --service-account $$SERVICE_ACCOUNT \
         --set-env-vars=\


### PR DESCRIPTION
### Description
Small change: sets a maximum number of instances for Cloud Run autoscaler. The default is 100, which is kind of crazy for our purposes, and now that we've bumped some of our CPU allocation up, Cloud Run doesn't like the possibility of 100 instances.

![image](https://github.com/WonderTix/WonderTix/assets/72955295/0018d822-47ad-4685-8b56-6a79c799dd5f)

### Risks
I suppose it's possible we could suddenly get slammed with traffic and have to scale higher than 10, but I don't foresee that happening any time soon.

### Validation
I built and deployed from this branch to `dev`, then promoted across `stg` and `prd`. No issues, and I've got receipts:

- https://console.cloud.google.com/cloud-build/builds;region=us-west2/8ca36ce8-bf53-4b14-8d74-5e6463744c11?project=wondertix-app
- https://console.cloud.google.com/cloud-build/builds;region=us-west2/ffc3e42c-a3b7-4920-a280-b85d4754c7c9?project=wondertix-app
- https://console.cloud.google.com/cloud-build/builds;region=us-west2/9ed1f854-fe3c-4cd8-ac73-54200daf9055?project=wondertix-app
- https://console.cloud.google.com/cloud-build/builds;region=us-west2/a394e9d8-7dd5-400c-a090-f29b7f89184e?project=wondertix-app
- https://console.cloud.google.com/cloud-build/builds;region=us-west2/2987b752-461d-4d78-bfda-a2e569274139?project=wondertix-app
- https://console.cloud.google.com/cloud-build/builds;region=us-west2/522cbf0a-6603-4d2e-9e4b-c9bdd6fb657e?project=wondertix-app

### Issue
[DEP-77: add explicit max value for autoscaling](https://wondertix.atlassian.net/browse/DEP-77)

### Operating System
Ubuntu 22.04
