### PR TITLE
DEP-80: add CPU boost to improve container startup time

### DIFF
--- a/client/cloudbuild.yaml
+++ b/client/cloudbuild.yaml
@@ -45,6 +45,7 @@ steps:
         --platform managed \
         --memory $$CLIENT_MEMORY \
         --cpu $$CLIENT_CPU \
+        --cpu-boost \
         --allow-unauthenticated \
         --min-instances 1 \
         --max-instances 10 \

--- a/server/cloudbuild.yaml
+++ b/server/cloudbuild.yaml
@@ -24,6 +24,7 @@ steps:
         --platform managed \
         --memory $$SERVER_MEMORY \
         --cpu $$SERVER_CPU \
+        --cpu-boost \
         --allow-unauthenticated \
         --min-instances 1 \
         --max-instances 10 \


### PR DESCRIPTION
### Description
Previously this feature was manually enabled in our Cloud Run deployments. It effectively doubles the CPU instances allocated while a container spins up in order to shorten that startup time.

However, because this option wasn't specified in our `cloudbuild.yaml` files, migrating to a new Cloud Run revision meant it would be disabled by default.

This branch adds the `--cpu-boost` flag to the deploy step of our `cloudbuild.yaml` files to ensure this option is enabled without requiring manual intervention in the GCP web UI.

- Docs: https://cloud.google.com/run/docs/configuring/services/cpu#startup-boost

### Risks
None, really. We've already been using this feature for weeks.

### Validation
I manually deployed these changes to the `dev` environment. Here are the build logs:
- Server: https://console.cloud.google.com/cloud-build/builds;region=us-west2/5eca269b-b52d-40b8-9c65-c2f8d26ced8b?project=wondertix-app
- Client: https://console.cloud.google.com/cloud-build/builds;region=us-west2/7eb2800c-1426-4d40-9800-189a172295f1?project=wondertix-app

### Issue
- [*DEP-80: add CPU boost*](https://wondertix.atlassian.net/browse/DEP-80)

### Operating System
Arch Linux
