### PR TITLE
Added timezone to Docker.dev file

### DIFF
--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -10,6 +10,9 @@ FROM node:18-alpine
 # COPY /bin/wait-for-it.sh /usr/wait-for-it.sh
 # RUN chmod +x /usr/wait-for-it.sh
 
+RUN apk add --no-cache tzdata
+ENV TZ=America/Los_Angeles
+
 # Set the working directory inside the container
 WORKDIR /usr/app
 


### PR DESCRIPTION
### Description
Added two lines to the Docker.dev file to provide the server with correct timezone (PST).
### Risks
Changes are already reflected in our previous Dockerfile, minimal impact.

### Validation
Tested my branch on both the client and server and both builds passed.

### Issue
(https://wondertix.atlassian.net/jira/software/projects/DEP/boards/1?selectedIssue=DEP-66)

### Operating System
Windows 10
