### PR TITLE
[TIC-118] Rename Refund Ticket to Refund Orders

### DIFF
--- a/client/e2e/dashboard.test.ts
+++ b/client/e2e/dashboard.test.ts
@@ -9,18 +9,18 @@ test('Homepage->Ticketing Dashboard', async ({page}) => {
   await expect(dashboard.page).toHaveURL('/ticketing');
 });
 
-test('Ticketing Dashboard->Door List', async ({page}) => {
+test('Ticketing Dashboard->DoorList', async ({page}) => {
   const dashboard = new DashboardPage(page);
 
   await dashboard.DoorList();
-  await dashboard.backtoDashboard();
+  await dashboard.backToDashboard();
 });
 
 test('Ticketing Dashboard->Events', async ({page}) => {
   const dashboard = new DashboardPage(page);
 
   await dashboard.Events();
-  await dashboard.backtoDashboard();
+  await dashboard.backToDashboard();
 });
 
 test('Ticketing Dashboard->PurchaseTickets', async ({page}) => {
@@ -30,11 +30,18 @@ test('Ticketing Dashboard->PurchaseTickets', async ({page}) => {
   await dashboard.ticketingURL();
 });
 
+test('Ticketing Dashboard->Seasons', async ({page}) => {
+  const dashboard = new DashboardPage(page);
+
+  await dashboard.Seasons();
+  await dashboard.ticketingURL();
+});
+
 test('Ticketing Dashboard->CreateNewsletter', async ({page}) => {
   const dashboard = new DashboardPage(page);
 
   await dashboard.CreateNewsletter();
-  await dashboard.backtoDashboard();
+  await dashboard.backToDashboard();
 });
 
 test('Ticketing Dashboard->ManageSeasonalTickets', async ({page}) => {
@@ -47,12 +54,19 @@ test('Ticketing Dashboard->ManageTicketTypes', async ({page}) => {
   const dashboard = new DashboardPage(page);
 
   await dashboard.ManageTicketTypes();
-  await dashboard.backtoDashboard();
+  await dashboard.backToDashboard();
 });
 
 test('Ticketing Dashboard->TicketExchanges', async ({page}) => {
   const dashboard = new DashboardPage(page);
 
   await dashboard.TicketExchanges();
-  await dashboard.backtoDashboard();
+  await dashboard.backToDashboard();
+});
+
+test('Ticketing Dashboard->RefundOrders', async ({page}) => {
+  const dashboard = new DashboardPage(page);
+
+  await dashboard.RefundOrders();
+  await dashboard.backToDashboard();
 });

--- a/client/e2e/pages/dashboardPage.ts
+++ b/client/e2e/pages/dashboardPage.ts
@@ -3,30 +3,32 @@ import {type Locator, type Page, expect} from '@playwright/test';
 export class DashboardPage {
   readonly page: Page;
 
-  //Homepage
+  // Homepage
   readonly EmailButton: Locator;
   readonly ManageTicketing: Locator;
 
-  //../ticketing
+  // ../ticketing
   readonly TicketingHeading: Locator;
   readonly DoorListButton: Locator;
   readonly EventsButton: Locator;
   readonly PurchaseTicketsButton: Locator;
+  readonly SeasonsButton: Locator;
   readonly CreateNewsletterButton: Locator;
   readonly ManageSeasonalTicketsButton: Locator;
   readonly ManageTicketTypesButton: Locator;
   readonly TicketExchangesButton: Locator;
+  readonly RefundOrdersButton: Locator;
 
   readonly DashboardButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
 
-    //HOMEPAGE
+    // HOMEPAGE
     this.EmailButton = page.getByText('test@wondertix.com');
     this.ManageTicketing = page.getByText('Manage Ticketing').first();
 
-    //..//ticketing
+    // ..//ticketing
     this.TicketingHeading = page.getByRole('heading', {
       name: 'Ticketing Dashboard',
     });
@@ -35,6 +37,7 @@ export class DashboardPage {
     this.PurchaseTicketsButton = page.getByRole('button', {
       name: 'Purchase Tickets',
     });
+    this.SeasonsButton = page.getByRole('button', {name: 'Seasons'});
     this.CreateNewsletterButton = page.getByRole('button', {
       name: 'Create Newsletter',
     });
@@ -44,11 +47,14 @@ export class DashboardPage {
     this.ManageTicketTypesButton = page.getByRole('button', {
       name: 'Manage Ticket Types',
     });
-    this.TicketExchangesButton = page.getByRole('heading', {
+    this.TicketExchangesButton = page.getByRole('button', {
       name: 'Ticket Exchanges',
     });
+    this.RefundOrdersButton = page.getByRole('button', {
+      name: 'Refund Orders',
+    });
 
-    //Left sidebar
+    // Left sidebar
     this.DashboardButton = page
       .getByRole('list')
       .locator('a')
@@ -65,7 +71,7 @@ export class DashboardPage {
     await this.page.goto('/ticketing', {timeout: 90000});
   }
 
-  async backtoDashboard() {
+  async backToDashboard() {
     await this.DashboardButton.click();
     await expect(this.TicketingHeading).toBeVisible();
     await expect(this.page).toHaveURL('/ticketing');
@@ -78,7 +84,7 @@ export class DashboardPage {
       this.page.getByRole('heading', {name: 'Door List'}),
     ).toBeVisible();
     await expect(this.page).toHaveURL('/ticketing/doorlist');
-    await this.backtoDashboard();
+    await this.backToDashboard();
   }
   async Events() {
     await this.goto();
@@ -87,7 +93,7 @@ export class DashboardPage {
       this.page.getByRole('heading', {name: 'Select Event'}),
     ).toBeVisible();
     await expect(this.page).toHaveURL('/ticketing/showings');
-    await this.backtoDashboard();
+    await this.backToDashboard();
   }
   async PurchaseTickets() {
     await this.goto();
@@ -96,7 +102,16 @@ export class DashboardPage {
       this.page.getByRole('heading', {name: 'Purchase Tickets'}),
     ).toBeVisible();
     await expect(this.page).toHaveURL('/ticketing/purchaseticket');
-    await this.backtoDashboard();
+    await this.backToDashboard();
+  }
+  async Seasons() {
+    await this.goto();
+    await this.SeasonsButton.click();
+    await expect(
+      this.page.getByRole('heading', {name: 'Select Season'}),
+    ).toBeVisible();
+    await expect(this.page).toHaveURL('/ticketing/seasons');
+    await this.backToDashboard();
   }
   async CreateNewsletter() {
     await this.goto();
@@ -105,7 +120,7 @@ export class DashboardPage {
       this.page.getByRole('heading', {name: 'Newsletter Creation!'}),
     ).toBeVisible();
     await expect(this.page).toHaveURL('/ticketing/addnewsletter');
-    await this.backtoDashboard();
+    await this.backToDashboard();
   }
   async ManageSeasonalTickets() {
     await this.goto();
@@ -123,7 +138,7 @@ export class DashboardPage {
       this.page.getByRole('heading', {name: 'Manage Ticket Types'}),
     ).toBeVisible();
     await expect(this.page).toHaveURL('/ticketing/tickettypes');
-    await this.backtoDashboard();
+    await this.backToDashboard();
   }
   async TicketExchanges() {
     await this.goto();
@@ -132,6 +147,15 @@ export class DashboardPage {
       this.page.getByRole('heading', {name: 'Ticket Exchanges'}),
     ).toBeVisible();
     await expect(this.page).toHaveURL('/ticketing/ticketexchanges');
-    await this.backtoDashboard();
+    await this.backToDashboard();
+  }
+  async RefundOrders() {
+    await this.goto();
+    await this.RefundOrdersButton.click();
+    await expect(
+      this.page.getByRole('heading', {name: 'Refund Order'}),
+    ).toBeVisible();
+    await expect(this.page).toHaveURL('/ticketing/refund');
+    await this.backToDashboard();
   }
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -39,7 +39,7 @@ import AdminPurchasemain from './components/Ticketing/ticketingmanager/AdminPurc
 import AdminCheckoutmain from './components/Ticketing/ticketingmanager/AdminPurchase/AdminCheckoutmain';
 import PageNotFound from './components/Ticketing/mainpage/PageNotFound';
 import {EventProvider} from './components/Ticketing/ticketingmanager/showings/ShowingUpdated/EventProvider';
-import RefundMain from './components/Ticketing/ticketingmanager/Refund/RefundOrderTicketMain';
+import RefundOrdersMain from './components/Ticketing/ticketingmanager/RefundOrders/RefundOrdersMain';
 
 const App = () => {
   return (
@@ -160,7 +160,7 @@ const App = () => {
         />
         <Route
           path='/ticketing/Refund'
-          element={<ProtectedRoute component={RefundMain} />}
+          element={<ProtectedRoute component={RefundOrdersMain} />}
         />
         <Route path='*' element={<PageNotFound />} />
       </Routes>

--- a/client/src/components/Ticketing/ticketingmanager/RefundOrders/RefundOrders.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/RefundOrders/RefundOrders.tsx
@@ -2,8 +2,7 @@ import React, {useState} from 'react';
 import {useFetchToken} from '../showings/ShowingUpdated/ShowingUtils';
 import PopUp from '../../PopUp';
 
-
-const Refund = () => {
+const RefundOrders = () => {
   const {token} = useFetchToken();
   const [submitting, setSubmitting] = useState(false);
   const [orders, setOrders] = useState([]);
@@ -16,7 +15,15 @@ const Refund = () => {
     handleProceed: () => setShow({...show, showPopUp: false}),
     handleClose: () => setShow({...show, showPopUp: false}),
   });
-  const setPopUp = (title:string, message:string, success:boolean, showPopUp: boolean, handle, secondary) => {
+
+  const setPopUp = (
+    title: string,
+    message: string,
+    success: boolean,
+    showPopUp: boolean,
+    handle,
+    secondary,
+  ) => {
     setShow({
       ...show,
       title,
@@ -27,12 +34,11 @@ const Refund = () => {
       showSecondary: secondary,
     });
   };
-  const formatUSD = new Intl.NumberFormat(
-    'en-us',
-    {
-      currency: 'USD',
-      style: 'currency',
-    });
+
+  const formatUSD = new Intl.NumberFormat('en-us', {
+    currency: 'USD',
+    style: 'currency',
+  });
 
   const onRefund = async (orderID) => {
     try {
@@ -50,7 +56,9 @@ const Refund = () => {
       if (!response.ok) {
         throw response;
       }
-      setOrders((orders) => orders.filter((order) => order.orderid !== orderID));
+      setOrders((orders) =>
+        orders.filter((order) => order.orderid !== orderID),
+      );
       setPopUp(
         'Refund Successful',
         `Order ${orderID} successfully refunded`,
@@ -73,6 +81,7 @@ const Refund = () => {
       setSubmitting(false);
     }
   };
+
   const onFetchOrders = async (event) => {
     event.preventDefault();
     const email = event.target[0].value;
@@ -88,7 +97,8 @@ const Refund = () => {
       return;
     }
     try {
-      const response = await fetch(`${process.env.REACT_APP_API_2_URL}/order/refund?email=${email}`,
+      const response = await fetch(
+        `${process.env.REACT_APP_API_2_URL}/order/refund?email=${email}`,
         {
           credentials: 'include',
           method: 'get',
@@ -96,7 +106,8 @@ const Refund = () => {
             'Content-Type': 'application/json',
             'Authorization': `Bearer ${token}`,
           },
-        });
+        },
+      );
       if (!response.ok) {
         throw response;
       }
@@ -117,40 +128,52 @@ const Refund = () => {
 
   return (
     <>
-      {show.showPopUp &&
-      <PopUp
-        title={show.title}
-        message={show.message}
-        handleClose={show.handleClose}
-        handleProceed={show.handleProceed}
-        success={show.success}
-        showSecondary={show.showSecondary}
-      />
-      }
-      <div className='w-full h-screen overflow-x-hidden absolute '>
+      {show.showPopUp && (
+        <PopUp
+          title={show.title}
+          message={show.message}
+          handleClose={show.handleClose}
+          handleProceed={show.handleProceed}
+          success={show.success}
+          showSecondary={show.showSecondary}
+        />
+      )}
+      <div className='w-full h-screen overflow-x-hidden absolute'>
         <div className='md:ml-[18rem] md:mt-40 md:mb-[11rem] tab:mx-[5rem] mx-[1.5rem] my-[9rem]'>
           <h1 className='font-bold text-5xl bg-clip-text text-transparent bg-gradient-to-r from-sky-500 to-indigo-500 mb-14'>
-              Refund Ticket
+            Refund Order
           </h1>
           <form className='mb-4' onSubmit={onFetchOrders}>
             <div className='flex'>
-              <svg xmlns="http://www.w3.org/2000/svg" className="pointer-events-none h-5 w-5 absolute ml-6 mt-3" viewBox="0 0 20 20" fill="gray">
-                <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
-                <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+              <svg
+                xmlns='http://www.w3.org/2000/svg'
+                className='pointer-events-none h-5 w-5 absolute ml-6 mt-3'
+                viewBox='0 0 20 20'
+                fill='gray'
+              >
+                <path d='M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z' />
+                <path d='M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z' />
               </svg>
-              <label className = 'hidden'>
-                Email
-              </label>
               <input // search button
                 type='email'
                 className='text-black border-2 border-gray rounded-l-full pl-12 w-80 py-2'
                 id='email'
                 placeholder='John_Smith@email.com'
+                aria-label='email'
               />
               <button id='email-search-input' type='submit' className='px-0'>
                 <div className='hover:bg-sky-500 w-20 rounded-r-full bg-indigo-500 hover:drop-shadow-md active:bg-sky-600'>
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-11 w-11 pl-6" viewBox="0 0 20 20" fill="white">
-                    <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd" />
+                  <svg
+                    xmlns='http://www.w3.org/2000/svg'
+                    className='h-11 w-11 pl-6'
+                    viewBox='0 0 20 20'
+                    fill='white'
+                  >
+                    <path
+                      fill-rule='evenodd'
+                      d='M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z'
+                      clip-rule='evenodd'
+                    />
                   </svg>
                 </div>
               </button>
@@ -159,37 +182,49 @@ const Refund = () => {
           <table className={'w-full min-w-min'}>
             <thead>
               <tr className='grid grid-cols-5 gap-2 bg-gray-200 h-18 rounded-lg shadow-md px-2 mb-2 font-bold'>
-                <td className='row-start-1 justify-self-start py-2 col-span-1'>Name</td>
-                <td className='row-start-1 justify-self-start py-2 col-span-1'>Order Date & Time</td>
-                <td className='row-start-1 justify-self-start py-2 col-span-1'>Event(s)</td>
-                <td className='row-start-1 justify-self-start py-2 col-span-1'>Order Total</td>
+                <td className='row-start-1 justify-self-start py-2 col-span-1'>
+                  Name
+                </td>
+                <td className='row-start-1 justify-self-start py-2 col-span-1'>
+                  Order Date & Time
+                </td>
+                <td className='row-start-1 justify-self-start py-2 col-span-1'>
+                  Event(s)
+                </td>
+                <td className='row-start-1 justify-self-start py-2 col-span-1'>
+                  Order Total
+                </td>
                 <td className='row-start-1 justify-self-center py-2 col-span-1'></td>
               </tr>
             </thead>
             <tbody>
               {orders.length === 0 ? (
-                <tr className="text-center text-gray-600">
+                <tr className='text-center text-gray-600'>
                   <td className={'col-span-5'}>
-                    <p>
-                    No Refundable Orders
-                    </p>
+                    <p>No Refundable Orders</p>
                   </td>
                 </tr>
               ) : (
                 orders.map((instance, index) => (
-                  <tr key={index} className='grid grid-cols-5 gap-2 bg-gray-200 rounded-lg shadow-md px-2 mb-2 hover:bg-gray-300'>
+                  <tr
+                    key={index}
+                    className='grid grid-cols-5 gap-2 bg-gray-200 rounded-lg shadow-md px-2 mb-2 hover:bg-gray-300'
+                  >
                     <td className='row-start-1 justify-self-start pl-2 py-2 col-span-1'>
                       {instance.name}
                     </td>
                     <td className='row-start-1 justify-self-start pl-2 py-2 col-span-1'>
-                      {new Date(`${instance.orderdate} ${instance.ordertime.split('T')[1].slice(0, 6)}`)
-                        .toLocaleString('en-us', {
-                          month: '2-digit',
-                          day: '2-digit',
-                          year: '2-digit',
-                          hour: '2-digit',
-                          minute: '2-digit',
-                        })}
+                      {new Date(
+                        `${instance.orderdate} ${instance.ordertime
+                          .split('T')[1]
+                          .slice(0, 6)}`,
+                      ).toLocaleString('en-us', {
+                        month: '2-digit',
+                        day: '2-digit',
+                        year: '2-digit',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
                     </td>
                     <td className='row-start-1 justify-self-start pl-2 py-2 col-span-1'>
                       {Array.isArray(instance.showings) ? (
@@ -206,7 +241,7 @@ const Refund = () => {
                     <td className='row-start-1 justify-self-start py-2 col-span-1'>
                       <button
                         disabled={submitting}
-                        onClick={ () =>
+                        onClick={() =>
                           setPopUp(
                             'Confirm Refund',
                             'Click continue to refund',
@@ -219,15 +254,16 @@ const Refund = () => {
                               return;
                             },
                             true,
-                          )}
+                          )
+                        }
                         type='button'
                         className='bg-red-600 hover:bg-red-700 focus:ring-red-500 dark:focus:ring-red-800
-                        w-full inline-flex justify-center rounded-md border border-transparent
-                        shadow-sm px-4 py-2 text-base font-medium text-white
-                        focus:outline-none focus:ring-2 focus:ring-offset-2
-                       tab:ml-3 tab:w-auto tab:text-sm disabled:bg-gray-500'
+                          w-full inline-flex justify-center rounded-md border border-transparent
+                          shadow-sm px-4 py-2 text-base font-medium text-white
+                          focus:outline-none focus:ring-2 focus:ring-offset-2
+                          tab:ml-3 tab:w-auto tab:text-sm disabled:bg-gray-500'
                       >
-                      Refund
+                        Refund
                       </button>
                     </td>
                   </tr>
@@ -241,4 +277,4 @@ const Refund = () => {
   );
 };
 
-export default Refund;
+export default RefundOrders;

--- a/client/src/components/Ticketing/ticketingmanager/RefundOrders/RefundOrdersMain.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/RefundOrders/RefundOrdersMain.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import Udash_nav from '../udash_navbar';
-import Refund from './RefundOrderTicket';
+import RefundOrders from './RefundOrders';
 
 /**
  * Hosts refund page
  *
  * @returns {Navbar, RefundPage, Footer}
  */
-const RefundMain = () => {
+const RefundOrdersMain = () => {
   return (
     <div className='flex flex-row'>
-      <Udash_nav/>
-      <Refund/>
+      <Udash_nav />
+      <RefundOrders />
     </div>
   );
 };
 
-export default RefundMain;
+export default RefundOrdersMain;

--- a/client/src/components/Ticketing/ticketingmanager/dashboard.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/dashboard.tsx
@@ -196,7 +196,7 @@ const Dashboard = (): ReactElement => {
                 />
               </svg>
             }
-            title='Refund Ticket'
+            title='Refund Orders'
             route='/ticketing/refund'
           />
         </div>


### PR DESCRIPTION
### Description
Renamed instances of `Refund Ticket` to `Refund Orders` so it better represents the functionality of Refunds. This is something that I noticed after-the-fact. I also Renamed some of the files so that the components' names match their file names. Also some prettier changes

Also updated the E2E tests to include refunds and seasons pages.

### Risks
None

### Validation
Manual testing

### Issue
[TIC-118](https://pdx-hkaus.atlassian.net/browse/TIC-118)

### Operating System
Windows 11

[TIC-118]: https://pdx-hkaus.atlassian.net/browse/TIC-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ