### PR TITLE
TIC-124: Migrate Season page to utilized v2 events API instead of v1

### DIFF
--- a/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
@@ -41,7 +41,7 @@ const SeasonEvents = (props: SeasonEventsProps) => {
 
     eventToUpdate = {
       ...eventToUpdate,
-      seasonid_fk: undefined,
+      seasonid_fk: null,
     };
 
     const updateEventCall = await updateEventSeason(eventToUpdate, token);

--- a/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
@@ -19,11 +19,12 @@ const SeasonEvents = (props: SeasonEventsProps) => {
   const handleGetAllEvents = async () => {
     const allEvents = await getAllEvents(token);
     if (allEvents) {
-      const {data} = allEvents;
-      const eventsInSeason = data.filter(
-        (event) => event.seasonid === seasonId,
+      const eventsInSeason = allEvents.filter(
+        (event) => event.seasonid_fk === seasonId,
       );
-      const eventsNotInSeason = data.filter((event) => event.seasonid === null);
+      const eventsNotInSeason = allEvents.filter(
+        (event) => event.seasonid_fk === null,
+      );
 
       setAllEventInfo(eventsInSeason);
       setEventsNotInSeason(eventsNotInSeason);
@@ -32,38 +33,22 @@ const SeasonEvents = (props: SeasonEventsProps) => {
 
   const handleRemoveEvent = async (eventIdToRemove: number) => {
     const updatedEvents = allEventInfo.filter(
-      (event) => Number(event.id) !== eventIdToRemove,
+      (event) => Number(event.eventid) !== eventIdToRemove,
     );
     let eventToUpdate = allEventInfo.find(
-      (event) => Number(event.id) === eventIdToRemove,
+      (event) => Number(event.eventid) === eventIdToRemove,
     );
-    const eventToUpdateCopy = {...eventToUpdate};
 
-    // Temporary solution until Events API is updated (Line 43 - 62)
-    // Fetch all event API returns data with different property names than what update event API requires as payload
-    const {
-      id: eventId,
-      description: eventDescription,
-      title: eventName,
-    } = eventToUpdate;
     eventToUpdate = {
       ...eventToUpdate,
-      eventid: eventId,
-      eventname: eventName,
-      eventdescription: eventDescription,
       seasonid_fk: null,
     };
-    delete eventToUpdate['id'];
-    delete eventToUpdate['seasonid'];
-    delete eventToUpdate['seasonticketeligible'];
-    delete eventToUpdate['numshows'];
-    delete eventToUpdate['description'];
-    delete eventToUpdate['title'];
+    delete eventToUpdate['deletedat'];
 
     const updateEventCall = await updateEventSeason(eventToUpdate, token);
     if (updateEventCall) {
       setAllEventInfo(updatedEvents);
-      setEventsNotInSeason([...eventsNotInSeason, eventToUpdateCopy]);
+      setEventsNotInSeason([...eventsNotInSeason, eventToUpdate]);
     }
   };
 
@@ -200,9 +185,9 @@ const SeasonEvents = (props: SeasonEventsProps) => {
             eventsNotInSeason.map((event) => {
               return (
                 <EventCard
-                  key={event.id}
-                  eventId={event.id}
-                  name={event.title}
+                  key={event.eventid}
+                  eventId={event.eventid}
+                  name={event.eventname}
                   imageurl={event.imageurl}
                   addEventCard={true}
                   addEventToSeason={handleAddEventToSeason}
@@ -219,10 +204,10 @@ const SeasonEvents = (props: SeasonEventsProps) => {
       {allEventInfo.map((event) => {
         return (
           <EventCard
-            key={event.id}
-            name={event.title}
+            key={event.eventid}
+            name={event.eventname}
             imageurl={event.imageurl}
-            eventId={event.id}
+            eventId={event.eventid}
             isFormEditing={isFormEditing}
             isAddEventActive={isAddEventActive}
             deleteEventConfirmationHandler={deleteEventConfirmationHandler}

--- a/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
@@ -19,14 +19,14 @@ const SeasonEvents = (props: SeasonEventsProps) => {
   const handleGetAllEvents = async () => {
     const allEvents = await getAllEvents(token);
     if (allEvents) {
-      const eventsInSeason = allEvents.filter(
+      const eventsInCurrentSeason = allEvents.filter(
         (event) => event.seasonid_fk === seasonId,
       );
       const unassignedEvents = allEvents.filter(
         (event) => event.seasonid_fk === null,
       );
 
-      setEventsInSeason(eventsInSeason);
+      setEventsInSeason(eventsInCurrentSeason);
       setEventsNotInAnySeason(unassignedEvents);
     }
   };

--- a/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
@@ -155,9 +155,9 @@ const SeasonEvents = (props: SeasonEventsProps) => {
                 fill='currentColor'
               >
                 <path
-                  fill-rule='evenodd'
+                  fillRule='evenodd'
                   d='M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z'
-                  clip-rule='evenodd'
+                  clipRule='evenodd'
                 />
               </svg>
               <p>Close</p>

--- a/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
@@ -13,7 +13,7 @@ interface SeasonEventsProps {
 const SeasonEvents = (props: SeasonEventsProps) => {
   const {seasonId, token, isFormEditing, setShowPopUp, setPopUpMessage} = props;
   const [allEventInfo, setAllEventInfo] = useState<any>([]);
-  const [eventsNotInSeason, setEventsNotInSeason] = useState<any>([]);
+  const [eventsNotInASeason, setEventsNotInASeason] = useState<any>([]);
   const [isAddEventActive, setIsAddEventActive] = useState<boolean>(false);
 
   const handleGetAllEvents = async () => {
@@ -22,12 +22,12 @@ const SeasonEvents = (props: SeasonEventsProps) => {
       const eventsInSeason = allEvents.filter(
         (event) => event.seasonid_fk === seasonId,
       );
-      const eventsNotInSeason = allEvents.filter(
+      const unassignedEvents = allEvents.filter(
         (event) => event.seasonid_fk === null,
       );
 
       setAllEventInfo(eventsInSeason);
-      setEventsNotInSeason(eventsNotInSeason);
+      setEventsNotInASeason(unassignedEvents);
     }
   };
 
@@ -47,7 +47,7 @@ const SeasonEvents = (props: SeasonEventsProps) => {
     const updateEventCall = await updateEventSeason(eventToUpdate, token);
     if (updateEventCall) {
       setAllEventInfo(updatedEvents);
-      setEventsNotInSeason([...eventsNotInSeason, eventToUpdate]);
+      setEventsNotInASeason([...eventsNotInASeason, eventToUpdate]);
     }
   };
 
@@ -66,10 +66,10 @@ const SeasonEvents = (props: SeasonEventsProps) => {
   };
 
   const handleAddEventToSeason = async (eventIdToAdd: number) => {
-    let eventToAdd = eventsNotInSeason.find(
+    let eventToAdd = eventsNotInASeason.find(
       (event) => Number(event.eventid) === eventIdToAdd,
     );
-    const updatedEventsNotInSeason = eventsNotInSeason.filter((event) => {
+    const updatedEventsNotInASeason = eventsNotInASeason.filter((event) => {
       return Number(event.eventid) !== eventIdToAdd;
     });
 
@@ -82,7 +82,7 @@ const SeasonEvents = (props: SeasonEventsProps) => {
     setShowPopUp(true);
     if (updateEventCall) {
       setAllEventInfo([...allEventInfo, eventToAdd]);
-      setEventsNotInSeason(updatedEventsNotInSeason);
+      setEventsNotInASeason(updatedEventsNotInASeason);
       setPopUpMessage({
         title: 'Success',
         message: 'The event has been added to the season!',
@@ -107,10 +107,10 @@ const SeasonEvents = (props: SeasonEventsProps) => {
   }, []);
 
   useEffect(() => {
-    if (eventsNotInSeason.length > 0) {
-      eventsNotInSeason.sort((a, b) => b.eventid - a.eventid);
+    if (eventsNotInASeason.length > 0) {
+      eventsNotInASeason.sort((a, b) => b.eventid - a.eventid);
     }
-  }, [eventsNotInSeason]);
+  }, [eventsNotInASeason]);
 
   return (
     <div className='rounded-xl p-7 bg-white text-lg mt-5 shadow-xl'>
@@ -163,8 +163,8 @@ const SeasonEvents = (props: SeasonEventsProps) => {
               <p>Close</p>
             </button>
           </div>
-          {eventsNotInSeason.length !== 0 ? (
-            eventsNotInSeason.map((event) => {
+          {eventsNotInASeason.length !== 0 ? (
+            eventsNotInASeason.map((event) => {
               return (
                 <EventCard
                   key={event.eventid}

--- a/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
@@ -41,7 +41,7 @@ const SeasonEvents = (props: SeasonEventsProps) => {
 
     eventToUpdate = {
       ...eventToUpdate,
-      seasonid_fk: null,
+      seasonid_fk: undefined,
     };
 
     const updateEventCall = await updateEventSeason(eventToUpdate, token);

--- a/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
@@ -12,8 +12,8 @@ interface SeasonEventsProps {
 
 const SeasonEvents = (props: SeasonEventsProps) => {
   const {seasonId, token, isFormEditing, setShowPopUp, setPopUpMessage} = props;
-  const [allEventInfo, setAllEventInfo] = useState<any>([]);
-  const [eventsNotInASeason, setEventsNotInASeason] = useState<any>([]);
+  const [eventsInSeason, setEventsInSeason] = useState<any>([]);
+  const [eventsNotInAnySeason, setEventsNotInAnySeason] = useState<any>([]);
   const [isAddEventActive, setIsAddEventActive] = useState<boolean>(false);
 
   const handleGetAllEvents = async () => {
@@ -26,16 +26,16 @@ const SeasonEvents = (props: SeasonEventsProps) => {
         (event) => event.seasonid_fk === null,
       );
 
-      setAllEventInfo(eventsInSeason);
-      setEventsNotInASeason(unassignedEvents);
+      setEventsInSeason(eventsInSeason);
+      setEventsNotInAnySeason(unassignedEvents);
     }
   };
 
   const handleRemoveEvent = async (eventIdToRemove: number) => {
-    const updatedEvents = allEventInfo.filter(
+    const updatedEvents = eventsInSeason.filter(
       (event) => Number(event.eventid) !== eventIdToRemove,
     );
-    let eventToUpdate = allEventInfo.find(
+    let eventToUpdate = eventsInSeason.find(
       (event) => Number(event.eventid) === eventIdToRemove,
     );
 
@@ -46,8 +46,8 @@ const SeasonEvents = (props: SeasonEventsProps) => {
 
     const updateEventCall = await updateEventSeason(eventToUpdate, token);
     if (updateEventCall) {
-      setAllEventInfo(updatedEvents);
-      setEventsNotInASeason([...eventsNotInASeason, eventToUpdate]);
+      setEventsInSeason(updatedEvents);
+      setEventsNotInAnySeason([...eventsNotInAnySeason, eventToUpdate]);
     }
   };
 
@@ -66,10 +66,10 @@ const SeasonEvents = (props: SeasonEventsProps) => {
   };
 
   const handleAddEventToSeason = async (eventIdToAdd: number) => {
-    let eventToAdd = eventsNotInASeason.find(
+    let eventToAdd = eventsNotInAnySeason.find(
       (event) => Number(event.eventid) === eventIdToAdd,
     );
-    const updatedEventsNotInASeason = eventsNotInASeason.filter((event) => {
+    const updatedEventsNotInASeason = eventsNotInAnySeason.filter((event) => {
       return Number(event.eventid) !== eventIdToAdd;
     });
 
@@ -81,8 +81,8 @@ const SeasonEvents = (props: SeasonEventsProps) => {
     const updateEventCall = await updateEventSeason(eventToAdd, token);
     setShowPopUp(true);
     if (updateEventCall) {
-      setAllEventInfo([...allEventInfo, eventToAdd]);
-      setEventsNotInASeason(updatedEventsNotInASeason);
+      setEventsInSeason([...eventsInSeason, eventToAdd]);
+      setEventsNotInAnySeason(updatedEventsNotInASeason);
       setPopUpMessage({
         title: 'Success',
         message: 'The event has been added to the season!',
@@ -107,10 +107,10 @@ const SeasonEvents = (props: SeasonEventsProps) => {
   }, []);
 
   useEffect(() => {
-    if (eventsNotInASeason.length > 0) {
-      eventsNotInASeason.sort((a, b) => b.eventid - a.eventid);
+    if (eventsNotInAnySeason.length > 0) {
+      eventsNotInAnySeason.sort((a, b) => b.eventid - a.eventid);
     }
-  }, [eventsNotInASeason]);
+  }, [eventsNotInAnySeason]);
 
   return (
     <div className='rounded-xl p-7 bg-white text-lg mt-5 shadow-xl'>
@@ -163,8 +163,8 @@ const SeasonEvents = (props: SeasonEventsProps) => {
               <p>Close</p>
             </button>
           </div>
-          {eventsNotInASeason.length !== 0 ? (
-            eventsNotInASeason.map((event) => {
+          {eventsNotInAnySeason.length !== 0 ? (
+            eventsNotInAnySeason.map((event) => {
               return (
                 <EventCard
                   key={event.eventid}
@@ -183,7 +183,7 @@ const SeasonEvents = (props: SeasonEventsProps) => {
           )}
         </div>
       )}
-      {allEventInfo.map((event) => {
+      {eventsInSeason.map((event) => {
         return (
           <EventCard
             key={event.eventid}

--- a/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
@@ -43,7 +43,6 @@ const SeasonEvents = (props: SeasonEventsProps) => {
       ...eventToUpdate,
       seasonid_fk: null,
     };
-    delete eventToUpdate['deletedat'];
 
     const updateEventCall = await updateEventSeason(eventToUpdate, token);
     if (updateEventCall) {
@@ -68,38 +67,21 @@ const SeasonEvents = (props: SeasonEventsProps) => {
 
   const handleAddEventToSeason = async (eventIdToAdd: number) => {
     let eventToAdd = eventsNotInSeason.find(
-      (event) => Number(event.id) === eventIdToAdd,
+      (event) => Number(event.eventid) === eventIdToAdd,
     );
-    const eventToAddCopy = {...eventToAdd};
     const updatedEventsNotInSeason = eventsNotInSeason.filter((event) => {
-      return Number(event.id) !== eventIdToAdd;
+      return Number(event.eventid) !== eventIdToAdd;
     });
 
-    // Temporary solution until Events API is updated (Line 94 - 113)
-    // Fetch all event API returns data with different property names than what update event API requires as payload
-    const {
-      id: eventId,
-      description: eventDescription,
-      title: eventName,
-    } = eventToAdd;
     eventToAdd = {
       ...eventToAdd,
-      eventid: eventId,
-      eventname: eventName,
-      eventdescription: eventDescription,
       seasonid_fk: seasonId,
     };
-    delete eventToAdd['id'];
-    delete eventToAdd['seasonid'];
-    delete eventToAdd['seasonticketeligible'];
-    delete eventToAdd['numshows'];
-    delete eventToAdd['description'];
-    delete eventToAdd['title'];
 
     const updateEventCall = await updateEventSeason(eventToAdd, token);
     setShowPopUp(true);
     if (updateEventCall) {
-      setAllEventInfo([...allEventInfo, eventToAddCopy]);
+      setAllEventInfo([...allEventInfo, eventToAdd]);
       setEventsNotInSeason(updatedEventsNotInSeason);
       setPopUpMessage({
         title: 'Success',

--- a/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonEvents.tsx
@@ -108,7 +108,7 @@ const SeasonEvents = (props: SeasonEventsProps) => {
 
   useEffect(() => {
     if (eventsNotInSeason.length > 0) {
-      eventsNotInSeason.sort((a, b) => b.id - a.id);
+      eventsNotInSeason.sort((a, b) => b.eventid - a.eventid);
     }
   }, [eventsNotInSeason]);
 

--- a/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonInfo.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonInfo.tsx
@@ -10,7 +10,6 @@ import {
 } from './utils/apiRequest';
 import {seasonDefaultValues, SeasonProps} from './utils/seasonCommon';
 import ViewSeasonInfo from './utils/ViewSeasonInfo';
-import {FormControlLabel, Checkbox} from '@mui/material';
 
 const SeasonInfo = (props: SeasonProps) => {
   const {
@@ -214,12 +213,13 @@ const SeasonInfo = (props: SeasonProps) => {
             />
           </label>
           <div id='form-checkboxes' className='flex gap-7'>
-            <div className='checkboxes'>
-              <FormControlLabel
-                control={<Checkbox />}
-                label='Use Default Image'
+            <div className='checkbox-2'>
+              <input
+                type='checkbox'
+                id='defaultImage'
+                name='defaultImage'
+                className='mr-2'
                 checked={imageCheckbox}
-                sx={{marginRight: '6rem'}}
                 onChange={() => {
                   setImageCheckbox((checked) => !checked);
                   setSeasonValues((seasonValues) => ({
@@ -228,10 +228,21 @@ const SeasonInfo = (props: SeasonProps) => {
                   }));
                 }}
               />
-
-              <FormControlLabel control={<Checkbox />} label='Active' />
+              <label className='text-base' htmlFor='defaultImage'>
+                Use Default Image
+              </label>
             </div>
-            <div className='checkbox-2'></div>
+            <div className='checkbox-2'>
+              <input
+                className='mr-2'
+                type='checkbox'
+                id='activeSeason'
+                name='activeSeason'
+              />
+              <label className='text-base' htmlFor='activeSeason'>
+                Active
+              </label>
+            </div>
           </div>
         </div>
         <article className='col-span-12 tab:col-span-6'>

--- a/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonInfo.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonInfo.tsx
@@ -10,6 +10,7 @@ import {
 } from './utils/apiRequest';
 import {seasonDefaultValues, SeasonProps} from './utils/seasonCommon';
 import ViewSeasonInfo from './utils/ViewSeasonInfo';
+import {FormControlLabel, Checkbox} from '@mui/material';
 
 const SeasonInfo = (props: SeasonProps) => {
   const {
@@ -213,13 +214,12 @@ const SeasonInfo = (props: SeasonProps) => {
             />
           </label>
           <div id='form-checkboxes' className='flex gap-7'>
-            <div className='checkbox-2'>
-              <input
-                type='checkbox'
-                id='defaultImage'
-                name='defaultImage'
-                className='mr-2'
+            <div className='checkboxes'>
+              <FormControlLabel
+                control={<Checkbox />}
+                label='Use Default Image'
                 checked={imageCheckbox}
+                sx={{marginRight: '6rem'}}
                 onChange={() => {
                   setImageCheckbox((checked) => !checked);
                   setSeasonValues((seasonValues) => ({
@@ -228,21 +228,10 @@ const SeasonInfo = (props: SeasonProps) => {
                   }));
                 }}
               />
-              <label className='text-base' htmlFor='defaultImage'>
-                Use Default Image
-              </label>
+
+              <FormControlLabel control={<Checkbox />} label='Active' />
             </div>
-            <div className='checkbox-2'>
-              <input
-                className='mr-2'
-                type='checkbox'
-                id='activeSeason'
-                name='activeSeason'
-              />
-              <label className='text-base' htmlFor='activeSeason'>
-                Active
-              </label>
-            </div>
+            <div className='checkbox-2'></div>
           </div>
         </div>
         <article className='col-span-12 tab:col-span-6'>

--- a/client/src/components/Ticketing/ticketingmanager/Season/components/utils/apiRequest.ts
+++ b/client/src/components/Ticketing/ticketingmanager/Season/components/utils/apiRequest.ts
@@ -138,7 +138,7 @@ export const deleteSeasonInfo = async (seasonId: number, token: string) => {
 export const getAllEvents = async (token: string) => {
   try {
     const getAllEventsRes = await fetch(
-      process.env.REACT_APP_API_1_URL + '/events',
+      process.env.REACT_APP_API_2_URL + '/events',
       {
         credentials: 'include',
         method: 'GET',
@@ -167,7 +167,7 @@ export const updateEventSeason = async (
 ) => {
   try {
     const updateEventSeasonRes = await fetch(
-      process.env.REACT_APP_API_1_URL + '/events',
+      process.env.REACT_APP_API_2_URL + '/events',
       {
         credentials: 'include',
         method: 'PUT',

--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -743,7 +743,7 @@ eventController.put('/', async (req: Request, res: Response) => {
         eventid: Number(req.body.eventid),
       },
       data: {
-        seasonid_fk: req.body.seasonid_fk,
+        seasonid_fk: Number(req.body.seasonid_fk),
         eventname: req.body.eventname,
         eventdescription: req.body.eventdescription,
         active: req.body.active,

--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -743,7 +743,7 @@ eventController.put('/', async (req: Request, res: Response) => {
         eventid: Number(req.body.eventid),
       },
       data: {
-        seasonid_fk: Number(req.body.seasonid_fk),
+        seasonid_fk: req.body.seasonid_fk,
         eventname: req.body.eventname,
         eventdescription: req.body.eventdescription,
         active: req.body.active,

--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -743,7 +743,7 @@ eventController.put('/', async (req: Request, res: Response) => {
         eventid: Number(req.body.eventid),
       },
       data: {
-        seasonid_fk: Number(req.body.seasonid_fk),
+        seasonid_fk: req.body.seasonid_fk === null ? null : Number(req.body.seasonid_fk),
         eventname: req.body.eventname,
         eventdescription: req.body.eventdescription,
         active: req.body.active,

--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -679,7 +679,7 @@ eventController.post('/', async (req: Request, res: Response) => {
   try {
     const event = await prisma.events.create({
       data: {
-        seasonid_fk: req.body.seasonid_fk,
+        seasonid_fk: req.body.seasonid_fk === null ? null : Number(req.body.seasonid_fk),
         eventname: req.body.eventname,
         eventdescription: req.body.eventdescription,
         active: req.body.active,


### PR DESCRIPTION
### Description
Update Season page to utilized most-up-date events API that was changed recently. 

### Risks
Little to minimal risks, simply updated which API was being used and removed code that was no longer needed

### Validation
Test in the UI to ensure everything still functions as normal and double check database for changes.

### Issue
https://pdx-hkaus.atlassian.net/jira/software/projects/TIC/boards/1?selectedIssue=TIC-124

### Operating System
M2 Macbook
