### PR TITLE
[TIC-120] Group Toggle for Seasons Page with new API Call

### DIFF
--- a/client/src/components/Ticketing/ticketingmanager/Season/SeasonInstancesPage.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/SeasonInstancesPage.tsx
@@ -28,32 +28,57 @@ const SeasonInstancesPage = (props: SeasonInstancesProp) => {
   const {token} = props;
   const [filterSetting, setFilterSetting] = useState('active');
   const [seasonData, setSeasonData] = useState([]);
-
+  const [allSeasonData, setAllSeasonData] = useState([]);
+  const [inactiveData, setInactiveData] = useState([]);
+  const [activeData, setActiveData] = useState([]);
 
   useEffect(() => {
-    let apiURL;
-
-    if (filterSetting === 'active') {
-      apiURL = process.env.REACT_APP_API_2_URL + '/season/active';
-    } else if (filterSetting === 'inactive') {
-      apiURL = process.env.REACT_APP_API_2_URL + '/season/inactive';
-    } else {
-      apiURL = process.env.REACT_APP_API_2_URL + '/season';
-    }
-
-    fetch(apiURL, {
+    fetch(process.env.REACT_APP_API_2_URL + '/season/list', {
       headers: {
         'Authorization': `Bearer ${token}`,
       },
     })
     .then((response) => response.json())
     .then((data) => {
-      console.log('Received Season Data:', data);
-      setSeasonData([...data.toSorted()].reverse());
+      const inactiveSeasons = [];
+      const activeSeasons = [];
+      const allSeasons = [];
+
+      data.forEach((season) => {
+        const allEventsActive = season.events.every((event) => (event.active));
+
+        if (allEventsActive) {
+          activeSeasons.push(season);
+          allSeasons.push(season);
+        } else {
+          inactiveSeasons.push(season);
+          allSeasons.push(season);
+        }
+      });
+      // Set active/inactive/all data arrays
+      setInactiveData(inactiveSeasons);
+      setActiveData(activeSeasons);
+      setAllSeasonData(allSeasons);
+      // Set Default "Active"
+      setSeasonData(activeSeasons);
     })
     .catch((error) => {
       console.error('Error Fetching Season Data:', error);
     });
+  }, []);
+
+  // Group Toggle Display Changes
+  useEffect(() => {
+    if (filterSetting === 'active') {
+      // Active Data Only
+      setSeasonData([...activeData].sort((a, b) => b.seasonId - a.seasonId));
+    } else if (filterSetting === 'inactive') {
+      // Inactive Data Only
+      setSeasonData([...inactiveData].sort((a, b) => b.seasonId - a.seasonId));
+    } else {
+      // All Seasons
+      setSeasonData([...allSeasonData].sort((a, b) => b.seasonId - a.seasonId));
+    }
   }, [filterSetting]);
 
   return (

--- a/client/src/components/Ticketing/ticketingmanager/Season/SeasonInstancesPage.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/SeasonInstancesPage.tsx
@@ -26,45 +26,35 @@ interface SeasonInstancesProp {
 const SeasonInstancesPage = (props: SeasonInstancesProp) => {
   const navigate = useNavigate();
   const {token} = props;
-  const [seasons, setAllSeasons] = useState<Seasons[]>([]);
+  const [filterSetting, setFilterSetting] = useState('active');
+  const [seasonData, setSeasonData] = useState([]);
 
-  const getAllSeasons = async () => {
-    try {
-      const getAllSeasonsRes = await fetch(
-        process.env.REACT_APP_API_2_URL + '/season',
-        {
-          credentials: 'include',
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${token}`,
-          },
-        },
-      );
-
-      if (!getAllSeasonsRes.ok) {
-        throw new Error('Failed to fetch all seasons');
-      }
-
-      const seasonsData = await getAllSeasonsRes.json();
-      setAllSeasons(seasonsData);
-    } catch (error) {
-      console.error(error);
-    }
-  };
 
   useEffect(() => {
-    getAllSeasons();
-  }, []);
+    let apiURL;
 
-  /**
-   * Based on active/inactive/all
-   *
-   * @param event
-   */
-  const handleEventChange = (event) => {
-    // TODO: handle the season type change when active/inactive is properly implemented
-  };
+    if (filterSetting === 'active') {
+      apiURL = process.env.REACT_APP_API_2_URL + '/season/active';
+    } else if (filterSetting === 'inactive') {
+      apiURL = process.env.REACT_APP_API_2_URL + '/season/inactive';
+    } else {
+      apiURL = process.env.REACT_APP_API_2_URL + '/season';
+    }
+
+    fetch(apiURL, {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
+    })
+    .then((response) => response.json())
+    .then((data) => {
+      console.log('Received Season Data:', data);
+      setSeasonData([...data.toSorted()].reverse());
+    })
+    .catch((error) => {
+      console.error('Error Fetching Season Data:', error);
+    });
+  }, [filterSetting]);
 
   return (
     <div className='w-full h-screen overflow-x-hidden absolute'>
@@ -99,9 +89,12 @@ const SeasonInstancesPage = (props: SeasonInstancesProp) => {
             Add Season
           </button>
         </section>
-        <ShowingActivenessToggle defaultValue='active' />
+        <ShowingActivenessToggle
+          defaultValue={filterSetting}
+          handleFilterChange={setFilterSetting}
+        />
         <ul className='md:grid md:grid-cols-2 md:gap-8 grid grid-cols-1 gap-4 mt-9'>
-          {seasons.map((season) => (
+          {seasonData.map((season) => (
             <li key={season.seasonid}>
               <button
                 onClick={() =>

--- a/server/src/controllers/seasonController.ts
+++ b/server/src/controllers/seasonController.ts
@@ -146,6 +146,96 @@ seasonController.get('/', async (req: Request, res: Response) => {
 });
 
 /**
+ * Retrieves a list of seasons with their associated events.
+ *
+ * @swagger
+ * /2/season/list:
+ *   get:
+ *     summary: Get all seasons with events
+ *     tags:
+ *     - Season
+ *     responses:
+ *       200:
+ *         description: Successful response with an array of seasons and their events.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   seasonId:
+ *                     type: number
+ *                     description: The unique identifier of the season.
+ *                   seasonName:
+ *                     type: string
+ *                     description: The name of the season.
+ *                   events:
+ *                     type: array
+ *                     description: An array of events associated with the season.
+ *                     items:
+ *                       type: object
+ *                       properties:
+ *                         eventId:
+ *                           type: number
+ *                           description: The unique identifier of the event.
+ *                         eventName:
+ *                           type: string
+ *                           description: The name of the event.
+ *       400:
+ *         description: Bad request. Invalid input parameters.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   description: Error message from the server.
+ *       500:
+ *         description: Internal Server Error. An error occurred while processing the request.
+ *
+ * @param {Object} req - Express request object.
+ * @param {Object} res - Express response object.
+ * @returns {Object} - JSON response with an array of seasons and their events.
+ */
+seasonController.get('/list', async (req: Request, res: Response) => {
+  try {
+    const events = await prisma.seasons.findMany({
+      where: {},
+      include: {
+        events: true,
+      },
+    });
+
+    const seasonEvents = events.map((season) => {
+      return {
+        seasonId: season.seasonid,
+        seasonName: season.name,
+
+        events: season.events.map((event) => {
+          return {
+            eventId: event.eventid,
+            eventName: event.eventname,
+          };
+        }),
+      };
+    });
+
+    return res.json(seasonEvents);
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      res.status(400).json({error: error.message});
+      return;
+    }
+    if (error instanceof Prisma.PrismaClientValidationError) {
+      res.status(400).json({error: error.message});
+      return;
+    }
+    return res.status(500).json({error: 'Internal Server Error'});
+  }
+});
+/**
  * @swagger
  * /2/season/{id}:
  *   get:


### PR DESCRIPTION
### Description
Created a new API call off of Prisma, `/season/list`, which list the seasons and events within.

Group Toggle is similar to Events Group Toggle where the options are Active/Inactive/All

Criteria:
Active: All events within the season must be active.
Inactive: At least 1 event is inactive in a season.
All: Combination display

Display is by most recent creation.

![image](https://github.com/WonderTix/WonderTix/assets/15915111/afd18172-0549-40e9-a63c-65bb91217b01)


### Risks
None known, API call is strict.

Documentation Block & Code in the `seasonController.ts` must be thoroughly reviewed due to inexperience with API.

### Validation
Manual Testing:
![image](https://github.com/WonderTix/WonderTix/assets/15915111/a1db3383-e15d-4b8e-b893-073da51e71d1)

Current seeded data show only known active season is "Easter Egg Hunt", where all events are active.

* There are 7 Seasons. For each of all inactive, all events within are seeded as inactive.

### Issue
[*Link to corresponding issue*](https://pdx-hkaus.atlassian.net/browse/TIC-120)

### Operating System
Win10/Chrome
