### PR TITLE
TIC-139 Fixed Order Time

### DIFF
--- a/server/src/controllers/orderController.service.ts
+++ b/server/src/controllers/orderController.service.ts
@@ -168,12 +168,17 @@ export const orderCancel = async (
 const getOrderDateAndTime = () => {
   const date = new Date();
 
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
   const year = date.getFullYear();
 
+  const orderdate = parseInt(`${year}${month}${day}`, 10);
+  const localOffset = date.getTimezoneOffset() * 60000; // offset in milliseconds
+  const adjustedDate = new Date(date.getTime() - localOffset);
+  const ordertime = adjustedDate.toISOString();
+
   return {
-    orderdate: year * 10000 + month * 100 + day,
-    ordertime: date.toISOString(),
+    orderdate,
+    ordertime,
   };
 };

--- a/server/src/controllers/orderController.service.ts
+++ b/server/src/controllers/orderController.service.ts
@@ -168,17 +168,11 @@ export const orderCancel = async (
 const getOrderDateAndTime = () => {
   const date = new Date();
 
-  const month = (date.getMonth() + 1).toString().padStart(2, '0');
-  const day = date.getDate().toString().padStart(2, '0');
-  const year = date.getFullYear();
+  const formatDatePart = (part: number) => part.toString().padStart(2, '0');
 
-  const orderdate = parseInt(`${year}${month}${day}`, 10);
-  const localOffset = date.getTimezoneOffset() * 60000; // offset in milliseconds
-  const adjustedDate = new Date(date.getTime() - localOffset);
-  const ordertime = adjustedDate.toISOString();
+  const orderdate = parseInt(`${date.getFullYear()}${formatDatePart(date.getMonth() + 1)}${formatDatePart(date.getDate())}`, 10);
 
-  return {
-    orderdate,
-    ordertime,
-  };
+  const ordertime = new Date(date.getTime() - date.getTimezoneOffset() * 60000).toISOString();
+
+  return {orderdate, ordertime};
 };


### PR DESCRIPTION
### Description
Fixed an issue where it would show the order time 8 hours ahead of the current time.
IE. a purchase at 1:00PM would show a time purchase at 9:00PM
Previous:
![image](https://github.com/WonderTix/WonderTix/assets/15915111/ae272ebd-c3be-48f1-abfc-dd7ccd303fa1)
New:
![image](https://github.com/WonderTix/WonderTix/assets/15915111/73a0b0c4-5f45-4454-bb30-29aaaa85333b)
*20:13 -> 8:13

When viewing purchase history within the contacts page, the time is correct as well.

### Risks
Unsure if being in a different timezone  will incorrectly set the time.

### Validation
Manual Testing

### Issue
[*Link to corresponding issue*](https://pdx-hkaus.atlassian.net/browse/TIC-139)

### Operating System
Win10/Chrome
