### PR TITLE
Tic 127: Corrected issue to allow user to select new date after hitting "Choose Different Date" on Events Page

### DIFF
--- a/client/src/components/Ticketing/event/EventInstanceSelect.tsx
+++ b/client/src/components/Ticketing/event/EventInstanceSelect.tsx
@@ -46,7 +46,7 @@ const EventInstanceSelect = (props: EventInstanceSelectProps) => {
       className='bg-zinc-800/50 text-white p-5 mt-5 mb-3 rounded-xl'
       id='time-select'
     >
-      <option className='text-zinc-300' disabled value={0}>
+      <option className='text-zinc-300' disabled selected={props.check === 'selectTime'}>
         select time
       </option>
       {props.eventInstances.map((s) => (

--- a/client/src/components/Ticketing/event/TicketPicker.tsx
+++ b/client/src/components/Ticketing/event/TicketPicker.tsx
@@ -395,6 +395,7 @@ const TicketPicker = (props: TicketPickerProps): ReactElement => {
               className='text-zinc-300'
               value=''
               disabled
+              selected={prompt === 'selectDate'}
             >
               select date
             </option>


### PR DESCRIPTION
### Description
When choosing a showing to purchase. If you were to choose a date, and then choose a time. And then select a different date, the time would already be selected and you wouldn’t be able to purchase any tickets until going back to the main page or refreshing the page

### Risks
N/A

### Validation
Able to go through whole process, after changing to new date and time

### Issue
TIC-127

### Operating System
Window
