### PR TITLE
Dep 100 add incrementing timeout to stripe

### DIFF
--- a/client/e2e/mainTest.spec.ts
+++ b/client/e2e/mainTest.spec.ts
@@ -61,8 +61,9 @@ test('check cart after ticket add', async ({page}) => {
 });
 
 // Order a ticket through Stripe using a valid customer and card and verify success message appears
-test('check stripe purchase', async ({page}) => {
-  test.setTimeout(80000);
+test('check stripe purchase', async ({page}, testInfo) => {
+  const timeoutAdd = testInfo.retry * 5000;
+  test.setTimeout(80000 + (timeoutAdd * 2)); // There are two places with extended timeouts
   const currentPatron = JohnDoe;
   const currentCard = ValidVisaCredit;
   const currentEvent = EventsInfo5;
@@ -74,8 +75,8 @@ test('check stripe purchase', async ({page}) => {
   await events.addNewShowing(currentShowing);
   try {
     await main.goto();
-    await main.purchaseTicket(currentPatron, currentCard, currentEvent);
-    await expect(main.stripeOrderConfirmation).toBeVisible({timeout: 15000});
+    await main.purchaseTicket(currentPatron, currentCard, currentEvent, {timeoutAdd: timeoutAdd});
+    await expect(main.stripeOrderConfirmation).toBeVisible({timeout: 15000 + timeoutAdd});
   } finally {
     await main.goto();
     await events.goToEventFromManage(EventsInfo5.eventFullName);
@@ -86,7 +87,8 @@ test('check stripe purchase', async ({page}) => {
 
 // Order a ticket through Stripe and ensure the contact appears on the Contact page.
 // The delete contact function is not working, so contacts cannot be cleared after order.
-test('check contact is added after order', async ({page}) => {
+test('check contact is added after order', async ({page}, testInfo) => {
+  const timeoutAdd = testInfo.retry * 5000;
   test.setTimeout(80000);
   const currentPatron = JohnDoe;
   const currentCard = ValidVisaCredit;
@@ -100,7 +102,7 @@ test('check contact is added after order', async ({page}) => {
   await events.addNewShowing(currentShowing);
   try {
     await main.goto();
-    await main.purchaseTicket(currentPatron, currentCard, currentEvent);
+    await main.purchaseTicket(currentPatron, currentCard, currentEvent, {timeoutAdd: timeoutAdd});
     await contacts.goto();
     await contacts.searchCustomer(currentPatron);
     await contacts.checkCustomer(currentPatron);
@@ -113,8 +115,9 @@ test('check contact is added after order', async ({page}) => {
 });
 
 // Select an accommodation during order and make sure it appears on the contact page with the associated person
-test('check order accommodations', async ({page}) => {
-  test.setTimeout(80000);
+test('check order accommodations', async ({page}, testInfo) => {
+  const timeoutAdd = testInfo.retry * 5000;
+  test.setTimeout(80000 + timeoutAdd);
   const currentPatron = JaneDoe;
   const currentCard = ValidVisaCredit;
   const currentEvent = EventsInfo5;
@@ -127,7 +130,7 @@ test('check order accommodations', async ({page}) => {
   await events.addNewShowing(currentShowing);
   try {
     await main.goto();
-    await main.purchaseTicket(currentPatron, currentCard, currentEvent);
+    await main.purchaseTicket(currentPatron, currentCard, currentEvent, {timeoutAdd: timeoutAdd});
     await contacts.goto();
     await contacts.searchCustomer(currentPatron);
     await contacts.checkCustomer(currentPatron);
@@ -173,8 +176,9 @@ test('check ticket inc/dec in cart', async ({page}) => {
 });
 
 // Order a ticket through stripe and ensure the ticket appears on the door list
-test('check order on door list', async ({page}) => {
-  test.setTimeout(100000);
+test('check order on door list', async ({page}, testInfo) => {
+  const timeoutAdd = testInfo.retry * 5000;
+  test.setTimeout(100000 + timeoutAdd);
   const currentPatron = JohnDoe;
   const currentCard = ValidVisaCredit;
   const currentEvent = EventsInfo6;
@@ -188,7 +192,7 @@ test('check order on door list', async ({page}) => {
   await events.addNewShowing(currentShowing);
   try {
     await main.goto();
-    await main.purchaseTicket(currentPatron, currentCard, currentEvent, quantity);
+    await main.purchaseTicket(currentPatron, currentCard, currentEvent, {qty: quantity, timeoutAdd: timeoutAdd});
     await doorList.goto();
     await doorList.searchShowing(currentEvent, currentShowing);
     await doorList.checkOrder(currentPatron, quantity);

--- a/client/e2e/pages/mainPage.ts
+++ b/client/e2e/pages/mainPage.ts
@@ -214,9 +214,9 @@ export class MainPage {
   // Fill out data on Stripe page.  Currently uses both a Customer and CreditCard.
   // Stripe is slow and sometimes has an account popup after email entry.
   // This function waits to see if it will pop up and handle it appropriately.
-  async fillStripeInfo(customer: Customer, ccInfo: CreditCard) {
+  async fillStripeInfo(customer: Customer, ccInfo: CreditCard, timeoutAdd=0) {
     await this.stripeEmail.fill(customer.email);
-    await this.page.waitForTimeout(10000);
+    await this.page.waitForTimeout(10000 + timeoutAdd);
     if (await this.page.getByText('Use your saved information').isVisible()) {
       this.page.getByRole('button', {name: 'Cancel'}).click();
     }
@@ -236,19 +236,22 @@ export class MainPage {
   // Takes in a customer, credit card, event, and an optional quantity of tickets to purchase.
   // Date, time, and ticket type will be selected randomly.
   // Qty will be used to determine quantity if passed, otherwise will use a random quantity as well.
-  async purchaseTicket(customer: Customer, creditCard: CreditCard, event: EventsInfo, qty=2) {
+  async purchaseTicket(customer: Customer, creditCard: CreditCard, event: EventsInfo, options?: {qty?: number, timeoutAdd?: number}) {
+    if (options == undefined) options = {qty: 2, timeoutAdd: 0};
+    if (options.qty == undefined) options.qty = 2;
+    if (options.timeoutAdd == undefined) options.timeoutAdd = 0;
     await this.goSelectShowing(event);
     // Rebuild randoms to use a fixed selection using the EventsInfo and ShowingsInfo
     await this.selectRandomDate();
     await this.selectRandomTime();
     await this.selectRandomTicketType();
-    await this.selectTicketQuantity(qty);
+    await this.selectTicketQuantity(options.qty);
     await this.clickGetTickets();
     await this.clickTakeMeThere();
     await this.clickCartCheckout();
     await this.fillCustomerInfo(customer);
     await this.clickCartNext();
-    await this.fillStripeInfo(customer, creditCard);
+    await this.fillStripeInfo(customer, creditCard, options.timeoutAdd);
     await this.clickStripeCheckout();
   }
 


### PR DESCRIPTION
### Description
Added an incremental timer to tests related to Stripe functionality.  Relevant timeouts will be increased by 5 seconds per retry.  Hopefully this will resolve issues with the tests failing due to slow API.

### Risks
Should be no risks, other than a slightly longer test on retry.

### Validation
Ran tests in local.

### Issue
https://wondertix.atlassian.net/browse/DEP-100?atlOrigin=eyJpIjoiMDI1ZTgzMTUwZmQ2NDhmZjlkZmZmMmNiZGU3OWI1OGMiLCJwIjoiaiJ9

### Operating System
Windows 11
