### PR TITLE
[TIC-143] Added Some Active Events in Season Indicator

### DIFF
--- a/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonInfo.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/components/SeasonInfo.tsx
@@ -30,6 +30,7 @@ const SeasonInfo = (props: SeasonProps) => {
   const [activeSeasonSwitch, setActiveSeasonSwitch] = useState<
     boolean | undefined
   >();
+  const [someActiveEvents, setSomeActiveEvents] = useState(false);
 
   const {name, startdate, enddate, imageurl} = seasonValues;
   const navigate = useNavigate();
@@ -158,8 +159,15 @@ const SeasonInfo = (props: SeasonProps) => {
   }, [seasonId]);
 
   useEffect(() => {
-    const isSeasonActive = eventsInSeason.every((event) => event.active);
+    let isSeasonActive = true;
+    let isActiveEvents = false;
+    eventsInSeason.forEach((event) => {
+      isSeasonActive = isSeasonActive && event.active;
+      isActiveEvents = isActiveEvents || event.active;
+    });
+
     setActiveSeasonSwitch(isSeasonActive);
+    setSomeActiveEvents((isActiveEvents));
   }, [eventsInSeason]);
 
   if (activeSeasonSwitch === undefined) return <LoadingScreen />;
@@ -257,8 +265,10 @@ const SeasonInfo = (props: SeasonProps) => {
     <ViewSeasonInfo
       {...seasonValues}
       activeSeasonSwitch={activeSeasonSwitch}
+      someActiveEvents={someActiveEvents}
       setIsFormEditing={setIsFormEditing}
       setActiveSeasonSwitch={setActiveSeasonSwitch}
+      setSomeActiveEvents={setSomeActiveEvents}
       handleUpdateSeasonEvents={handleUpdateSeasonEvents}
       deleteConfirmationHandler={deleteConfirmationHandler}
     />

--- a/client/src/components/Ticketing/ticketingmanager/Season/components/utils/ViewSeasonInfo.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/components/utils/ViewSeasonInfo.tsx
@@ -21,9 +21,11 @@ const MONTHS = [
 
 interface ViewSeasonInfoProps extends SeasonInfo {
   activeSeasonSwitch: boolean;
+  someActiveEvents: boolean;
   setIsFormEditing: (value) => void;
   handleUpdateSeasonEvents: (value) => void;
   setActiveSeasonSwitch: (value) => void;
+  setSomeActiveEvents: (value) => void;
   deleteConfirmationHandler: (event) => void;
 }
 
@@ -34,9 +36,11 @@ const ViewSeasonInfo = (props: ViewSeasonInfoProps) => {
     enddate,
     imageurl,
     activeSeasonSwitch,
+    someActiveEvents,
     setIsFormEditing,
     handleUpdateSeasonEvents,
     setActiveSeasonSwitch,
+    setSomeActiveEvents,
     deleteConfirmationHandler,
   } = props;
 
@@ -60,7 +64,7 @@ const ViewSeasonInfo = (props: ViewSeasonInfoProps) => {
           >
             {activeSeasonSwitch ? 'ACTIVE' : 'INACTIVE'}
           </span>
-          <Tooltip title={<p>Edit</p>} placement='top' arrow>
+          <Tooltip title='Edit' placement='top' arrow>
             <button
               data-testid='season-edit'
               className='flex justify-center items-center bg-gray-400 hover:bg-gray-500 disabled:bg-gray-500 text-white font-bold px-2 py-2 rounded-xl'
@@ -82,7 +86,7 @@ const ViewSeasonInfo = (props: ViewSeasonInfoProps) => {
               </svg>
             </button>
           </Tooltip>
-          <Tooltip title={<p>Delete</p>} placement='top' arrow>
+          <Tooltip title='Delete' placement='top' arrow>
             <button
               data-testid='season-delete'
               className='flex justify-center items-center bg-red-500 hover:bg-red-600 disabled:bg-gray-500 text-white font-bold px-2 py-2 rounded-xl'
@@ -108,26 +112,51 @@ const ViewSeasonInfo = (props: ViewSeasonInfoProps) => {
       </section>
       <div className='grid grid-cols-12'>
         <article className='col-span-12 mb-5 text-center tab:text-start tab:col-span-6'>
-          <h3 className='font-semibold'>Season Name </h3>
+          <h3 className='font-semibold'>Season Name</h3>
           <p className='mb-3 text-base'>{name}</p>
 
-          <h3 className='font-semibold'>Start Date </h3>
+          <h3 className='font-semibold'>Start Date</h3>
           <p className='mb-3 text-base'>{getLongDateFormat(startdate)}</p>
 
-          <h3 className='font-semibold'>End Date </h3>
+          <h3 className='font-semibold'>End Date</h3>
           <p className='mb-3 text-base'>{getLongDateFormat(enddate)}</p>
 
-          <div>
+          <div className='flex items-center'>
             <FormControlLabel
               control={<Switch checked={activeSeasonSwitch} />}
               onChange={() => {
                 setActiveSeasonSwitch((checked) => !checked);
+                setSomeActiveEvents((someActiveEvents) => !someActiveEvents);
                 void handleUpdateSeasonEvents(!activeSeasonSwitch);
               }}
               sx={{margin: 0}}
-              label={<p className='text-sm text-zinc-800 font-medium pr-2'>Active:</p>}
+              label={
+                <p className='text-sm text-zinc-800 font-medium pr-2'>
+                  Active:
+                </p>
+              }
               labelPlacement='start'
             />
+            {!activeSeasonSwitch && someActiveEvents && (
+              <Tooltip
+                title='One or more events within this season are active'
+                placement='top-start'
+                arrow
+              >
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  className='h-5 w-5 text-zinc-400'
+                  fill='currentColor'
+                  viewBox='0 0 20 20'
+                >
+                  <path
+                    fillRule='evenodd'
+                    d='M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z'
+                    clipRule='evenodd'
+                  />
+                </svg>
+              </Tooltip>
+            )}
           </div>
         </article>
         <article className='col-span-12 tab:col-span-6'>

--- a/client/src/components/Ticketing/ticketingmanager/Season/components/utils/ViewSeasonInfo.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Season/components/utils/ViewSeasonInfo.tsx
@@ -131,7 +131,7 @@ const ViewSeasonInfo = (props: ViewSeasonInfoProps) => {
               }}
               sx={{margin: 0}}
               label={
-                <p className='text-sm text-zinc-800 font-medium pr-2'>
+                <p className='text-zinc-800 font-semibold pr-2'>
                   Active:
                 </p>
               }


### PR DESCRIPTION
### Description
Added an indicator to the SeasonInfo page that displays when a season is inactive, yet some of the events within that season are active. The indicator would not appear for active seasons or fully inactive seasons.

**This example has all but 1 event active:**
![image](https://github.com/WonderTix/WonderTix/assets/92124260/cde12565-287f-4388-b95d-b94ec5bc688a)

I'm not too sure that the tooltip makes enough sense so I could use some feedback on the verbiage.

### Risks
None

### Validation
Visual testing

### Issue
[TIC-143](https://pdx-hkaus.atlassian.net/browse/TIC-143)

### Operating System
Windows 11

[TIC-143]: https://pdx-hkaus.atlassian.net/browse/TIC-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ