### PR TITLE
DEP-109: reduce workers used by E2E tests

### DIFF
--- a/gcp/scripts/test-client.sh
+++ b/gcp/scripts/test-client.sh
@@ -10,6 +10,7 @@ required=(
 )
 source ${CHECK_ARGS} "${required[@]}"
 
+export CI="true"
 export DEPLOYED="true" # use minimal reporting
 export FRONTEND_URL="${CLIENT_REVISION}"
 export ROOT_URL="${SERVER_REVISION}"


### PR DESCRIPTION
### Description
- Exports the `CI` variable for containers running E2E tests on GCP

Running with the now-default four workers slows down our tests enough to cause some of them to fail. This change sets the `CI` variable to `true` within our Playwright containers on GCP, which takes the number of workers down to two. The tests which were failing previously are now passing again.

### Risks
- Changes a few other settings like timeouts and retries, but these should already be configured with deployment in mind.

### Validation
- Before:
  
  ![image](https://github.com/WonderTix/WonderTix/assets/72955295/f258d875-231c-4142-b4eb-1db6eadb340d)

- After:

  ![image](https://github.com/WonderTix/WonderTix/assets/72955295/e41ebc59-35d9-48ff-bad8-bda115cd2b97)

  - Note that the `check stripe purchase` test has other unresolved issues right now.

- Build log:
  - https://console.cloud.google.com/cloud-build/builds;region=us-west2/f212d342-dc14-44ea-97ec-53ab6d26c0c7?project=wondertix-app

### Issue
- [*DEP-109: reduce number of workers running tests*](https://wondertix.atlassian.net/browse/DEP-109)

### Operating System
- Ubuntu 22.04
