### PR TITLE
Conditionally seed database 

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -19,6 +19,9 @@ CI=false
 # dates, ticket types, discounts etc. See seed.ts in server/prisma
 MINIMAL_SEED=false
 
+# Whether or not to seed the database with any test data
+SHOULD_SEED=false
+
 # For Playwright E2E Testing
 TEST_EMAIL=none
 TEST_PASSWORD=none

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -180,6 +180,7 @@ steps:
       - 'SERVER_CPU'
       - 'SERVER_MEMORY'
       - 'SERVICE_ACCOUNT'
+      - 'SHOULD_SEED'
       - 'SQL_INSTANCE'
 
   # Send traffic to new server
@@ -337,6 +338,8 @@ availableSecrets:
     env: 'SERVER_REVISION'
   - versionName: projects/${PROJECT_ID}/secrets/SERVICE_ACCOUNT/versions/${_ENV}
     env: 'SERVICE_ACCOUNT'
+  - versionName: projects/${PROJECT_ID}/secrets/SHOULD_SEED/versions/${_ENV}
+    env: 'SHOULD_SEED'
   - versionName: projects/${PROJECT_ID}/secrets/SQL_INSTANCE/versions/${_ENV}
     env: 'SQL_INSTANCE'
   - versionName: projects/${PROJECT_ID}/secrets/TEST_EMAIL/versions/${_ENV}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       ROOT_URL: ${ROOT_URL}
       ENV: local
       CI: ${CI}
+      SHOULD_SEED: ${SHOULD_SEED}
     volumes:
       - ./server:/usr/app
       - /usr/app/node_modules

--- a/gcp/scripts/deploy-server.sh
+++ b/gcp/scripts/deploy-server.sh
@@ -10,6 +10,7 @@ required=(
   "SERVER_MEMORY"
   "SERVICE_ACCOUNT"
   "SHORT_SHA"
+  "SHOULD_SEED"
   "SQL_INSTANCE"
 )
 source ${CHECK_ARGS} "${required[@]}"
@@ -62,7 +63,8 @@ gcloud run deploy "wtix-server-${ENV}" \
   AUTH0_URL=${AUTH0_URL},\
   ENV=${ENV},\
   FRONTEND_URL=${FRONTEND_URL},\
-  ROOT_URL=${ROOT_URL}" \
+  ROOT_URL=${ROOT_URL} \
+  SHOULD_SEED=${SHOULD_SEED}" \
   --set-secrets="\
   AUTH0_CLIENT_SECRET=AUTH0_CLIENT_SECRET:${ENV},\
   DATABASE_URL=DATABASE_URL:${ENV},\

--- a/server/cloudbuild.yaml
+++ b/server/cloudbuild.yaml
@@ -31,6 +31,7 @@ steps:
       - 'SERVER_CPU'
       - 'SERVER_MEMORY'
       - 'SERVICE_ACCOUNT'
+      - 'SHOULD_SEED'
       - 'SQL_INSTANCE'
 
   # Send traffic to new revision
@@ -72,5 +73,7 @@ availableSecrets:
     env: 'SERVER_MEMORY'
   - versionName: projects/${PROJECT_ID}/secrets/SERVICE_ACCOUNT/versions/${_ENV}
     env: 'SERVICE_ACCOUNT'
+  - versionName: projects/${PROJECT_ID}/secrets/SHOULD_SEED/versions/${_ENV}
+    env: 'SHOULD_SEED'
   - versionName: projects/${PROJECT_ID}/secrets/SQL_INSTANCE/versions/${_ENV}
     env: 'SQL_INSTANCE'

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -33,38 +33,45 @@ const prisma = new PrismaClient();
 async function main() {
   const isCI = process.env.CI === 'true';
   const isMinimalSeed = process.env.MINIMAL_SEED === 'true';
+  const shouldSeed = process.env.SHOULD_SEED === 'true';
 
-  if (isCI || isMinimalSeed) {
-    // In CI environment, seed only necessary data
-    await importDates(prisma);
-    await importDiscounts(prisma);
-    await importTicketTypes(prisma);
+  if (shouldSeed) {
+    if (isCI || isMinimalSeed) {
+      // In CI environment, seed only necessary data
+      await importDates(prisma);
+      await importDiscounts(prisma);
+      await importTicketTypes(prisma);
+    } else {
+      // Full seeding process
+      await importDates(prisma);
+      await importUsers(prisma);
+      await importContacts(prisma);
+      await importDonations(prisma);
+      await importSeasons(prisma);
+      await importDiscounts(prisma);
+      await importTicketTypes(prisma);
+      await importEvents(prisma);
+      await importEventInstances(prisma);
+      await importTicketRestrictions(prisma);
+      await importOrders(prisma);
+      await importOrderItems(prisma);
+      await importSeasonTicketTypes(prisma);
+
+      // PPH SEEDING HERE
+      await importPPHAccounts(prisma);
+      await importPPHContacts(prisma);
+      await importPPHEvents(prisma);
+      await importPPHNotes(prisma);
+      await importPPHRecordTypes(prisma);
+      await importPPHOpportunity(prisma);
+      await importPPHTicketOrders(prisma);
+      await importPPHTicketOrderItems(prisma);
+      await importPPHTransactions(prisma);
+    }
   } else {
-    // Full seeding process
-    await importDates(prisma);
-    await importUsers(prisma);
-    await importContacts(prisma);
-    await importDonations(prisma);
-    await importSeasons(prisma);
-    await importDiscounts(prisma);
+    // There are two special ticketTypes ('pay what you can' and another default type) that have to be seeded with specific id values
     await importTicketTypes(prisma);
-    await importEvents(prisma);
-    await importEventInstances(prisma);
-    await importTicketRestrictions(prisma);
-    await importOrders(prisma);
-    await importOrderItems(prisma);
-    await importSeasonTicketTypes(prisma);
-
-    // PPH SEEDING HERE
-    await importPPHAccounts(prisma);
-    await importPPHContacts(prisma);
-    await importPPHEvents(prisma);
-    await importPPHNotes(prisma);
-    await importPPHRecordTypes(prisma);
-    await importPPHOpportunity(prisma);
-    await importPPHTicketOrders(prisma);
-    await importPPHTicketOrderItems(prisma);
-    await importPPHTransactions(prisma);
+    await importDates(prisma);
   }
 }
 

--- a/server/prisma/yaml-seeder-data/tickettype.yaml
+++ b/server/prisma/yaml-seeder-data/tickettype.yaml
@@ -9,15 +9,3 @@
   price: $20.00
   concessions: $0.00
   deprecated: false
-
-- tickettypeid: 2
-  description: General Admission - Child
-  price: $10.00
-  concessions: $0.00
-  deprecated: false
-
-- tickettypeid: 3
-  description: VIP
-  price: $30.00
-  concessions: $0.00
-  deprecated: false


### PR DESCRIPTION
### Description
Adds a `SHOULD_SEED` environment variable so that the database is only seeded with essential data on startup if it's set to `true`. The essential data being two ticketTypes that are each expected to have specific id values in other places in code, so those two types have to be specifically seeded (the altered sequence for the id value can be found at the end of the first db migration), as well as all the `date` table values 

The goal of this is to have staging and production environments that aren't filled with test data every time code's promoted 

Created the secret in gcp with versions for each env [here](https://console.cloud.google.com/security/secret-manager/secret/SHOULD_SEED/versions?project=wondertix-app)

### Risks
May have missed some environment variable configuration in some place(s)

### Validation
DB is only seeded with expected values locally for both true and false values 

### Issue
https://github.com/WonderTix/WonderTix/issues/521

### Operating System
win10
