### PR TITLE
DEP-110: add conditional seeding for test server

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ Once tests have been written, they can be organized in various ways. Possibly cr
 
 Expect a much more detailed Playwright tutorial and how-to in the very near future. Currently, I recommend visiting the [Playwright](https://playwright.dev/docs/intro).
 
-## Deployment
+## CI/CD
 
-`/gcbrun` comment: When an external contributor submits a pull request, the trigger won't automatically run. A repository collaborator or owner must review the pull request. If they deem the changes safe and want to proceed with the build or whatever the trigger initiates, they will comment on the pull request with `/gcbrun`. Only after this comment is made will the trigger be invoked, and the GCP build and deployment will proceed.
+Broadly speaking, we use GitHub Actions for continuous integration and Google Cloud Platform for continuous deployment.
+
+Unit tests and sandboxed E2E tests run via GitHub Actions whenever a pull request is opened or updated. The corresponding workflows can be found in the `.github` directory.
+
+Deployed E2E tests run automatically via Cloud Build trigger when a commit (typically a pull request) is merged to the `main` branch. Note that if these tests fail, the `main` branch will be left in an erroneous state: in other words, if there's a red `X` at the top of this page, something needs to be fixed. If the tests pass, the changes will go live on the `dev` deployment on Cloud Run.
+
+The `cloudbuild.yaml` files in this repo define the workflows that run on Cloud Build. The one at the root level is the main `test-and-deploy` pipeline.
+
+More documentation on our GCP architecture is forthcoming. 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -71,6 +71,7 @@ steps:
       - 'SERVER_MEMORY'
       - 'SERVER_REVISION'
       - 'SERVICE_ACCOUNT'
+      - 'SHOULD_SEED'
       - 'SQL_INSTANCE'
 
   # Build client image with args for test revision


### PR DESCRIPTION
### Description
- Adds `SHOULD_SEED` environment variable to `deploy-test-server` step of main workflow.
- Updates `README.md`: removes outdated reference to `/gcbrun` and adds brief overview of CI/CD.

### Risks
- None worth noting.

### Validation
- Build log: https://console.cloud.google.com/cloud-build/builds;region=us-west2/63cb844f-7c10-4359-81f9-801cc154b81a?project=wondertix-app

### Issue
- Following up on this: https://github.com/WonderTix/WonderTix/pull/528#issuecomment-1862151673

### Operating System
- Ubuntu 22.04
