### PR TITLE
[WT-574] Fix refunded order items do not show in a contacts order history

### DIFF
--- a/server/src/controllers/orderController.service.ts
+++ b/server/src/controllers/orderController.service.ts
@@ -171,18 +171,6 @@ export const orderCancel = async (
             },
             data: {
               refunded: true,
-              singletickets: {
-                update: item.singletickets.map((singleticket) => ({
-                  where: {
-                    singleticketid: singleticket.singleticketid,
-                  },
-                  data: {
-                    eventtickets: {
-                      set: [],
-                    },
-                  },
-                })),
-              },
             },
           }),
         ),


### PR DESCRIPTION
### Description
When an order is refunded, it calls orderCancel, which sets refunded: true, but it also sets eventtickets to an empty array. This is what is causing the orderitems on the contact page to be empty after a refund.

### Risks
It could be that eventtickets is set to empty array for some other reason I'm unaware of, but if the intent is for the tickets bought to be shown in the contacts page after a refund, then this can't be done I believe.

### Validation
I made a test purchase, refunded that order, then verified that the refund was set to yes, and the order items were listed.

### Issue
[*Link to corresponding issue*](https://github.com/WonderTix/WonderTix/issues/574)

### Operating System
Windows 11
