### PR TITLE
[WT-443] Ticketing - Resize image in Admin Events and Admin Season Page properly

### DIFF
--- a/client/src/components/Ticketing/ticketingmanager/Event/components/EventGeneralForm.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Event/components/EventGeneralForm.tsx
@@ -257,7 +257,7 @@ export const EventGeneralForm = (props: EventGeneralFormProps) => {
             </div>
             <div className={'col-span-12 min-[450px]:col-span-6'}>
               <EventImage
-                className={'mx-auto w-[50%] h-auto'}
+                className={'mx-auto w-auto h-auto max-h-[175px]'}
                 src={values.imageurl}
                 title='Supplied By User for Event'
               />

--- a/client/src/components/Ticketing/ticketingmanager/Event/components/EventGeneralForm.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Event/components/EventGeneralForm.tsx
@@ -257,7 +257,7 @@ export const EventGeneralForm = (props: EventGeneralFormProps) => {
             </div>
             <div className={'col-span-12 min-[450px]:col-span-6'}>
               <EventImage
-                className={'mx-auto w-[50%] h-auto max-w-[150px]'}
+                className={'mx-auto w-[50%] h-auto'}
                 src={values.imageurl}
                 title='Supplied By User for Event'
               />

--- a/client/src/components/Ticketing/ticketingmanager/Event/components/EventGeneralView.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Event/components/EventGeneralView.tsx
@@ -141,7 +141,7 @@ export const EventGeneralView = (props: EventGeneralViewProps) => {
         </div>
         <div className={'col-span-12 min-[450px]:col-span-6'}>
           <EventImage
-            className={'block mx-auto w-[50%] h-auto'}
+            className={'block mx-auto w-auto h-auto max-h-[175px]'}
             src={eventData.imageurl}
             title={'Event Image'}
           />

--- a/client/src/components/Ticketing/ticketingmanager/Event/components/EventGeneralView.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/Event/components/EventGeneralView.tsx
@@ -141,7 +141,7 @@ export const EventGeneralView = (props: EventGeneralViewProps) => {
         </div>
         <div className={'col-span-12 min-[450px]:col-span-6'}>
           <EventImage
-            className={'block mx-auto w-[50%] h-auto max-w-[125px]'}
+            className={'block mx-auto w-[50%] h-auto'}
             src={eventData.imageurl}
             title={'Event Image'}
           />


### PR DESCRIPTION
### Description
Image is resized according to screen size like described in #443.

### Risks
May want to set another max width or height.

### Validation
Manually tested

### Issue
Issue #443 

### Operating System
Windows 11 22H2 (23631.3296)

### Before:
![image](https://github.com/WonderTix/WonderTix/assets/43871473/64e8f630-fd34-4997-9fe7-ffa07cb2ed9b)

### After:
![image](https://github.com/WonderTix/WonderTix/assets/43871473/48b26f17-4e87-44ea-9fe6-e3759bc1d816)

