### PR TITLE
[WT-640] Update sold out indicators & update available seats within ticketing state

### DIFF
--- a/client/src/components/Ticketing/cart/CartItem.tsx
+++ b/client/src/components/Ticketing/cart/CartItem.tsx
@@ -3,6 +3,8 @@ import {
   editItemQty,
   editSubscriptionQty,
   isTicketCartItem,
+  removeSubscriptionFromCart,
+  removeTicketFromCart,
   SubscriptionCartItem,
   TicketCartItem,
 } from '../ticketingmanager/ticketingSlice';
@@ -12,10 +14,13 @@ import {
   getSeasonImageDefault,
 } from '../../../utils/imageURLValidation';
 import {formatUSD} from '../ticketingmanager/RefundOrders/RefundOrders';
+import Label from '../Label';
 
 interface CartRowProps {
   item: TicketCartItem | SubscriptionCartItem;
   removeHandler: () => void;
+  availability: number;
+  setPopUp: (value: boolean) => void;
 }
 
 /**
@@ -23,16 +28,43 @@ interface CartRowProps {
  *
  * @param {TicketCartItem | SubscriptionCartItem} item
  * @param {func} removeHandler
+ * @param {func} setPopUp
+ * @param {number} availability
  * @returns {ReactElement}
  */
-const CartRow = ({item, removeHandler}: CartRowProps): ReactElement => {
+const CartRow = ({
+  item,
+  removeHandler,
+  availability,
+  setPopUp,
+}: CartRowProps): ReactElement => {
   const dispatch = useAppDispatch();
+  const [quantityAdjusted, setQuantityAdjusted] = useState(false);
   const [cost, setCost] = useState(
     isTicketCartItem(item) && item.payWhatPrice
       ? item.payWhatPrice
       : item.price * item.qty,
   );
   const isTicketItem = isTicketCartItem(item);
+
+  useEffect(() => {
+    if (availability > 0 && availability < item.qty) {
+      setQuantityAdjusted(true);
+      handleUpdateQuantity(availability - item.qty);
+    } else if (availability === 0) {
+      if (isTicketItem) {
+        dispatch(
+          removeTicketFromCart({
+            id: item.product_id,
+            tickettypeId: item.typeID,
+          }),
+        );
+      } else {
+        dispatch(removeSubscriptionFromCart({...item}));
+      }
+      setPopUp(true);
+    }
+  }, []);
 
   useEffect(
     () =>
@@ -48,8 +80,8 @@ const CartRow = ({item, removeHandler}: CartRowProps): ReactElement => {
     ? getEventImageDefault
     : getSeasonImageDefault;
 
-  const handleUpdateQuantity = (update: 'increment' | 'decrement') => {
-    const updatedQty = update === 'increment'? item.qty+1: item.qty-1;
+  const handleUpdateQuantity = (update: number) => {
+    const updatedQty = item.qty + update;
     if (updatedQty < 1) {
       removeHandler();
     } else if (isTicketItem) {
@@ -72,7 +104,7 @@ const CartRow = ({item, removeHandler}: CartRowProps): ReactElement => {
 
   return (
     <div
-      className='w-full h-40 rounded-xl bg-cover'
+      className='w-full h-45 rounded-xl bg-cover'
       style={{
         backgroundImage: `url(${getImage(
           item.product_img_url,
@@ -87,72 +119,79 @@ const CartRow = ({item, removeHandler}: CartRowProps): ReactElement => {
           <p className='font-semibold'>{item.name}</p>
           <p className='text-zinc-200'>{item.desc}</p>
         </div>
-        <div className='flex items-center gap-7'>
-          <div className='flex items-center gap-2'>
+        <div className='flex flex-col gap-2'>
+          <div className='flex items-center gap-7'>
+            <div className='flex items-center gap-2'>
+              <button
+                className='enabled:hover:text-gray-300'
+                data-testid='decrement-item'
+                aria-label={`Remove one ${item.name} from cart`}
+                onClick={() => handleUpdateQuantity(-1)}
+              >
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  className='h-5 w-5'
+                  viewBox='0 0 20 20'
+                  fill='currentColor'
+                >
+                  <path
+                    fillRule='evenodd'
+                    d='M5 10a1 1 0 011-1h8a1 1 0 110 2H6a1 1 0 01-1-1z'
+                    clipRule='evenodd'
+                  />
+                </svg>
+              </button>
+              <p data-testid='item-quantity'>{item.qty}</p>
+              <button
+                className='enabled:hover:text-gray-300'
+                data-testid='increment-item'
+                aria-label={`Add one ${item.name} to cart`}
+                onClick={() => handleUpdateQuantity(1)}
+              >
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  className='h-5 w-5'
+                  viewBox='0 0 20 20'
+                  fill='currentColor'
+                >
+                  <path
+                    fillRule='evenodd'
+                    d='M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z'
+                    clipRule='evenodd'
+                  />
+                </svg>
+              </button>
+            </div>
+            <p data-testid='card-item-subtotal' className='font-semibold'>
+              {formatUSD(cost)}
+            </p>
             <button
               className='enabled:hover:text-gray-300'
-              data-testid='decrement-item'
-              aria-label={`Remove one ${item.name} from cart`}
-              onClick={() => handleUpdateQuantity('decrement')}
+              data-testid='remove-item'
+              aria-label={`Remove ${item.name} from cart`}
+              onClick={removeHandler}
             >
               <svg
                 xmlns='http://www.w3.org/2000/svg'
-                className='h-5 w-5'
-                viewBox='0 0 20 20'
-                fill='currentColor'
+                className='h-6 w-6'
+                fill='none'
+                viewBox='0 0 24 24'
+                stroke='currentColor'
+                strokeWidth={2}
               >
                 <path
-                  fillRule='evenodd'
-                  d='M5 10a1 1 0 011-1h8a1 1 0 110 2H6a1 1 0 01-1-1z'
-                  clipRule='evenodd'
-                />
-              </svg>
-            </button>
-            <p data-testid='item-quantity'>{item.qty}</p>
-            <button
-              className='enabled:hover:text-gray-300'
-              data-testid='increment-item'
-              aria-label={`Add one ${item.name} to cart`}
-              onClick={() => handleUpdateQuantity('increment')}
-            >
-              <svg
-                xmlns='http://www.w3.org/2000/svg'
-                className='h-5 w-5'
-                viewBox='0 0 20 20'
-                fill='currentColor'
-              >
-                <path
-                  fillRule='evenodd'
-                  d='M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z'
-                  clipRule='evenodd'
+                  strokeLinecap='round'
+                  strokeLinejoin='round'
+                  d='M6 18L18 6M6 6l12 12'
                 />
               </svg>
             </button>
           </div>
-          <p data-testid='card-item-subtotal' className='font-semibold'>
-            {formatUSD(cost)}
-          </p>
-          <button
-            className='enabled:hover:text-gray-300'
-            data-testid='remove-item'
-            aria-label={`Remove ${item.name} from cart`}
-            onClick={removeHandler}
-          >
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              className='h-6 w-6'
-              fill='none'
-              viewBox='0 0 24 24'
-              stroke='currentColor'
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap='round'
-                strokeLinejoin='round'
-                d='M6 18L18 6M6 6l12 12'
-              />
-            </svg>
-          </button>
+          {quantityAdjusted && (
+            <Label color='red' className='px-0.5 py-1'>
+              QUANTITY ADJUSTED
+            </Label>
+          )}
         </div>
       </div>
     </div>

--- a/client/src/components/Ticketing/event/EventInstanceSelect.tsx
+++ b/client/src/components/Ticketing/event/EventInstanceSelect.tsx
@@ -51,7 +51,7 @@ const EventInstanceSelect = ({
         select time
       </option>
       {eventInstances.map((ticket) => {
-        const soldOut = ticket.availableseats === 0;
+        const soldOut = ticket.remainingtickets === 0;
         return (
           <option key={ticket.event_instance_id} value={ticket.event_instance_id} disabled={soldOut}>
             {soldOut && '[SOLD OUT] '}

--- a/client/src/components/Ticketing/event/TicketPicker.tsx
+++ b/client/src/components/Ticketing/event/TicketPicker.tsx
@@ -153,7 +153,7 @@ const getDateOptions = (
     .map((ticket) => {
       return {
         date: new Date(ticket.date),
-        soldOut: ticket.availableseats === 0,
+        soldOut: ticket.remainingtickets === 0,
       };
     })
     .sort((a, b) => a.date.getTime() - b.date.getTime());
@@ -265,7 +265,7 @@ const TicketPicker = (props: TicketPickerProps): ReactElement => {
             throw response;
           }
           const data = await response.json();
-          setNumAvail(data.ticketlimit - data.ticketssold);
+          setNumAvail(Math.min(data.ticketlimit - data.ticketssold, selectedTicket.availableseats));
         } catch (error) {
           console.error(error);
         }
@@ -474,7 +474,7 @@ const TicketPicker = (props: TicketPickerProps): ReactElement => {
             disabled={
               !qty ||
               !selectedTicket ||
-              qty > selectedTicket.availableseats ||
+              qty > numAvail ||
               (selectedTicketType.name === 'Pay What You Can' &&
                 (payWhatPrice == null || payWhatPrice < 0))
             }

--- a/client/src/components/Ticketing/event/TicketPicker.tsx
+++ b/client/src/components/Ticketing/event/TicketPicker.tsx
@@ -450,6 +450,7 @@ const TicketPicker = (props: TicketPickerProps): ReactElement => {
             className={
               selectedTicketType &&
               selectedTicketType.name === 'Pay What You Can'
+                && numAvail > 0
                 ? 'flex flex-col gap-2 mt-3 justify-center'
                 : 'hidden'
             }

--- a/client/src/components/Ticketing/ticketingmanager/AdminPurchase/AdminPurchase.tsx
+++ b/client/src/components/Ticketing/ticketingmanager/AdminPurchase/AdminPurchase.tsx
@@ -184,7 +184,7 @@ const AdminPurchase = () => {
 
     // determine how many seats for current event instance
     const {ticketlimit, ticketssold} = currentTicketRestriction;
-    const seatsForType = ticketlimit - ticketssold;
+    const seatsForType = Math.min(ticketlimit - ticketssold, row.availableseats);
 
     const updatedRows = eventData.map((r) => {
       if (r.id === row.id) {

--- a/client/src/components/Ticketing/ticketingmanager/ticketingSlice.spec.ts
+++ b/client/src/components/Ticketing/ticketingmanager/ticketingSlice.spec.ts
@@ -30,6 +30,7 @@ const ticket1: Ticket = {
   date: new Date('2021-07-31T19:00:00'),
   ticket_price: 15.99,
   availableseats: 34,
+  remainingtickets: 34,
   detail: '',
 };
 
@@ -40,6 +41,7 @@ const ticket2: Ticket = {
   date: new Date('2021-08-07T16:00:00'),
   ticket_price: 19.99,
   availableseats: 20,
+  remainingtickets: 20,
   detail: '',
 };
 

--- a/client/src/components/Ticketing/ticketingmanager/ticketingSlice.spec.ts
+++ b/client/src/components/Ticketing/ticketingmanager/ticketingSlice.spec.ts
@@ -187,6 +187,7 @@ describe('Ticketing slice', () => {
             admission_type: 'General Admission - Adult',
             ticket_price: 15.99,
             availableseats: 34,
+            remainingtickets: 34,
             date: new Date('2021-07-31T19:00:00'),
             detail: '',
           }, {
@@ -195,6 +196,7 @@ describe('Ticketing slice', () => {
             admission_type: 'General Admission - Adult',
             ticket_price: 19.99,
             availableseats: 20,
+            remainingtickets: 20,
             date: new Date('2021-08-07T16:00:00'),
             detail: '',
           }],
@@ -216,6 +218,18 @@ describe('Ticketing slice', () => {
       expect(res)
         .toEqual({
           ...ticketingInitState,
+          tickets: {
+            data: {
+              ...ticketingInitState.tickets.data,
+              byId: {
+                ...ticketingInitState.tickets.data.byId,
+                [1]: {
+                  ...ticketingInitState.tickets.data.byId[1],
+                  availableseats: ticketingInitState.tickets.data.byId[1].availableseats - 2,
+                },
+              },
+            },
+          },
           ticketCart: [newCartItem],
         });
       init = res;
@@ -226,6 +240,18 @@ describe('Ticketing slice', () => {
       expect(ticketReducer(init, addTicketToCart(payload)))
         .toEqual({
           ...init,
+          tickets: {
+            data: {
+              ...init.tickets.data,
+              byId: {
+                ...init.tickets.data.byId,
+                [1]: {
+                  ...init.tickets.data.byId[1],
+                  availableseats: init.tickets.data.byId[1].availableseats - 1,
+                },
+              },
+            },
+          },
           ticketCart: [{...newCartItem, qty: 3}],
         });
     });
@@ -233,18 +259,63 @@ describe('Ticketing slice', () => {
     // ticket 1 currently in cart
     it('editItemQty: can set qty = available', () => {
       expect(ticketReducer(init, editItemQty({id: 1, tickettypeId: 1, qty: ticket1.availableseats})))
-        .toEqual({...init, ticketCart: [{...newCartItem, qty: ticket1.availableseats}]});
+        .toEqual({
+          ...init,
+          tickets: {
+            data: {
+              ...init.tickets.data,
+              byId: {
+                ...init.tickets.data.byId,
+                [1]: {
+                  ...init.tickets.data.byId[1],
+                  availableseats: 0,
+                },
+              },
+            },
+          },
+          ticketCart: [{...newCartItem, qty: ticket1.availableseats}],
+        });
     });
 
     it('editItemQty: can\'t set qty > available', () => {
       expect(ticketReducer(init, editItemQty({id: 1, tickettypeId: 1, qty: ticket1.availableseats + 1})))
-        .toEqual({...init, ticketCart: [{...newCartItem, qty: ticket1.availableseats}]});
+        .toEqual({
+          ...init,
+          tickets: {
+            data: {
+              ...init.tickets.data,
+              byId: {
+                ...init.tickets.data.byId,
+                [1]: {
+                  ...init.tickets.data.byId[1],
+                  availableseats: 0,
+                },
+              },
+            },
+          },
+          ticketCart: [{...newCartItem, qty: ticket1.availableseats}],
+        });
     });
 
     it('editItemQty: item exists in cart', () => {
       const res = ticketReducer(init, editItemQty({id: 1, tickettypeId: 1, qty: 4}));
       expect(res)
-        .toEqual({...init, ticketCart: [{...newCartItem, qty: 4}]});
+        .toEqual({
+          ...init,
+          tickets: {
+            data: {
+              ...init.tickets.data,
+              byId: {
+                ...init.tickets.data.byId,
+                [1]: {
+                  ...init.tickets.data.byId[1],
+                  availableseats: ticket1.availableseats-4,
+                },
+              },
+            },
+          },
+          ticketCart: [{...newCartItem, qty: 4}],
+        });
       init = res;
     });
 
@@ -255,7 +326,22 @@ describe('Ticketing slice', () => {
 
     it('editItemQty: can\'t set negative qty', () => {
       expect(ticketReducer(init, editItemQty({id: 1, tickettypeId: 1, qty: -1})))
-        .toEqual({...init, ticketCart: [{...newCartItem, qty: 0}]});
+        .toEqual({
+          ...init,
+          tickets: {
+            data: {
+              ...init.tickets.data,
+              byId: {
+                ...init.tickets.data.byId,
+                [1]: {
+                  ...init.tickets.data.byId[1],
+                  availableseats: ticket1.availableseats,
+                },
+              },
+            },
+          },
+          ticketCart: [{...newCartItem, qty: 0}],
+        });
     });
   });
 });

--- a/client/src/components/Ticketing/ticketingmanager/ticketingSlice.ts
+++ b/client/src/components/Ticketing/ticketingmanager/ticketingSlice.ts
@@ -531,6 +531,9 @@ const getTicketQuantityRange = (
   const ticketRestriction = state.ticketrestrictions.find(
     byId(eventInstanceId, ticketTypeId),
   );
+  if (!ticketRestriction) {
+    return bound(0, 0);
+  }
   const ticketRestrictionAvailableSeats =
     ticketRestriction.ticketlimit - ticketRestriction.ticketssold;
   return bound(
@@ -549,7 +552,7 @@ const getTicketQuantityRange = (
  * @param currentTickets.data.byId
  * @param currentTickets.data.allIds
  */
-const getUpdatedByIdsObject = (
+const updateByIdObject = (
   currentTickets: {data: {byId: {[key: string]: Ticket}; allIds: number[]}},
   toUpdate: {id: number; qty: number}[],
 ) => ({
@@ -604,7 +607,7 @@ const addTicketReducer: CaseReducer<
 
     updatedState = {
       ...state,
-      tickets: getUpdatedByIdsObject(state.tickets, [
+      tickets: updateByIdObject(state.tickets, [
         {id, qty: ticketCartItem.qty - updatedQty},
       ]),
       ticketCart: updateTicketCartItem(state.ticketCart, {
@@ -624,7 +627,7 @@ const addTicketReducer: CaseReducer<
     updatedState = newCartItem
       ? {
           ...state,
-          tickets: getUpdatedByIdsObject(state.tickets, [
+          tickets: updateByIdObject(state.tickets, [
             {id, qty: -newCartItem.qty},
           ]),
           ticketCart: [...state.ticketCart, newCartItem],
@@ -679,7 +682,7 @@ const editQtyReducer: CaseReducer<
   const updatedState = {
     ...state,
     tickets: ticketItem
-      ? getUpdatedByIdsObject(state.tickets, [{id, qty: ticketItem.qty - updatedQty}])
+      ? updateByIdObject(state.tickets, [{id, qty: ticketItem.qty - updatedQty}])
       : state.tickets,
     ticketCart: updateTicketCartItem(state.ticketCart, {
       id,
@@ -740,7 +743,7 @@ const removeTicketFromCartReducer: CaseReducer<
   );
   const updatedState = {
     ...state,
-    tickets: getUpdatedByIdsObject(state.tickets, [{id, qty: qty}]),
+    tickets: updateByIdObject(state.tickets, [{id, qty: qty}]),
     ticketCart: ticketCart,
   };
 
@@ -776,7 +779,7 @@ const removeAllTicketsFromCartReducer: CaseReducer<ticketingState> = (
 ) => {
   const updatedState = {
     ...state,
-    tickets: getUpdatedByIdsObject(
+    tickets: updateByIdObject(
       state.tickets,
       state.ticketCart.map((ticket) => ({
         id: ticket.product_id,
@@ -811,7 +814,7 @@ const removeAllSubscriptionsFromCartReducer: CaseReducer<ticketingState> = (
 const removeAllItemsFromCartReducer: CaseReducer<ticketingState> = (state) => {
   const updatedState = {
     ...state,
-    tickets: getUpdatedByIdsObject(
+    tickets: updateByIdObject(
       state.tickets,
       state.ticketCart.map((ticket) => ({
         id: ticket.product_id,
@@ -905,7 +908,7 @@ const ticketingSlice = createSlice({
           ? action.payload.ticketRestrictions
           : [];
         state.tickets = action.payload.tickets
-          ? getUpdatedByIdsObject(
+          ? updateByIdObject(
               action.payload.tickets,
               state.ticketCart.map((ticket) => ({
                 id: ticket.product_id,

--- a/client/src/components/Ticketing/ticketingmanager/ticketingSlice.ts
+++ b/client/src/components/Ticketing/ticketingmanager/ticketingSlice.ts
@@ -85,6 +85,7 @@ export interface Ticket {
   ticket_price: number;
   totalseats?: number;
   availableseats: number;
+  remainingtickets: number;
   detail: string;
 }
 
@@ -265,7 +266,7 @@ export const fetchTicketingData = createAsyncThunk(
         [] as Ticket[],
       );
       const soldOut = tickets.reduce((soldOutAcc, currTicket) => {
-        return soldOutAcc && currTicket.availableseats === 0;
+        return soldOutAcc && currTicket.remainingtickets === 0;
       }, true);
 
       return {...event, soldOut};
@@ -517,12 +518,14 @@ const updateSubscriptionCartItem = (
  * @param eventInstanceId
  * @param ticketTypeId
  * @param ticket
+ * @param currentQty
  */
 const getTicketQuantityRange = (
   state: ticketingState,
   eventInstanceId: number,
   ticketTypeId: number,
   ticket: Ticket,
+  currentQty: number,
 ) => {
   const eventInstanceAvailableSeats = ticket.availableseats;
   const ticketRestriction = state.ticketrestrictions.find(
@@ -532,9 +535,38 @@ const getTicketQuantityRange = (
     ticketRestriction.ticketlimit - ticketRestriction.ticketssold;
   return bound(
     0,
-    Math.min(eventInstanceAvailableSeats, ticketRestrictionAvailableSeats),
+    Math.min(eventInstanceAvailableSeats, ticketRestrictionAvailableSeats)+currentQty,
   );
 };
+
+/**
+ * Updates available seats for the given id based on the qty provided
+ *
+ *
+ * @param currentTickets
+ * @param currentTickets.data
+ * @param toUpdate
+ * @param currentTickets.data.byId
+ * @param currentTickets.data.allIds
+ */
+const getUpdatedByIdsObject = (
+  currentTickets: {data: {byId: {[key: string]: Ticket}; allIds: number[]}},
+  toUpdate: {id: number; qty: number}[],
+) => ({
+  data: {
+    ...currentTickets.data,
+    byId: toUpdate.reduce(
+      (acc, {id, qty}) => ({
+        ...acc,
+        [id]: {
+          ...acc[id],
+          availableseats: Math.max(acc[id].availableseats + qty, 0),
+        },
+      }),
+      {...currentTickets.data.byId},
+    ),
+  },
+});
 
 /**
  * addTicketReducer adds a ticketReducer to the payload and checks the id similar to qtyReducer
@@ -557,18 +589,28 @@ const addTicketReducer: CaseReducer<
   if (!tickets.data.allIds.includes(id)) return state;
 
   const ticket = tickets.data.byId[id];
-  const validRange = getTicketQuantityRange(state, id, tickettype.id, ticket);
 
   const ticketCartItem = state.ticketCart.find(byId(id, tickettype.id));
   let updatedState: ticketingState;
 
   if (ticketCartItem) {
+    const updatedQty = getTicketQuantityRange(
+      state,
+      id,
+      tickettype.id,
+      ticket,
+      ticketCartItem.qty,
+    )(qty + ticketCartItem.qty);
+
     updatedState = {
       ...state,
+      tickets: getUpdatedByIdsObject(state.tickets, [
+        {id, qty: ticketCartItem.qty - updatedQty},
+      ]),
       ticketCart: updateTicketCartItem(state.ticketCart, {
         id,
         tickettypeId: tickettype.id,
-        qty: validRange(qty + ticketCartItem.qty),
+        qty: updatedQty,
         payWhatPrice,
       }),
     };
@@ -582,6 +624,9 @@ const addTicketReducer: CaseReducer<
     updatedState = newCartItem
       ? {
           ...state,
+          tickets: getUpdatedByIdsObject(state.tickets, [
+            {id, qty: -newCartItem.qty},
+          ]),
           ticketCart: [...state.ticketCart, newCartItem],
         }
       : {...state};
@@ -628,14 +673,18 @@ const editQtyReducer: CaseReducer<
   if (!state.tickets.data.allIds.includes(id)) return state;
 
   const ticket = state.tickets.data.byId[id];
-  const validRange = getTicketQuantityRange(state, id, tickettypeId, ticket);
+  const ticketItem = state.ticketCart.find(byId(id, tickettypeId));
+  const updatedQty = getTicketQuantityRange(state, id, tickettypeId, ticket, ticketItem?.qty ?? 0)(qty);
 
   const updatedState = {
     ...state,
+    tickets: ticketItem
+      ? getUpdatedByIdsObject(state.tickets, [{id, qty: ticketItem.qty - updatedQty}])
+      : state.tickets,
     ticketCart: updateTicketCartItem(state.ticketCart, {
       id,
       tickettypeId,
-      qty: validRange(qty),
+      qty: updatedQty,
     }),
   };
 
@@ -682,11 +731,17 @@ const removeTicketFromCartReducer: CaseReducer<
   PayloadAction<{id: number; tickettypeId: number}>
 > = (state, action) => {
   const {id, tickettypeId} = action.payload;
+  const {qty, ticketCart} = state.ticketCart.reduce(
+    (acc, ticket) =>
+      ticket.product_id === id && ticket.typeID === tickettypeId
+        ? {...acc, qty: ticket.qty}
+        : {...acc, ticketCart: [...acc.ticketCart, ticket]},
+    {qty: 0, ticketCart: []},
+  );
   const updatedState = {
     ...state,
-    ticketCart: state.ticketCart.filter(
-      (item) => item.product_id !== id || item.typeID !== tickettypeId,
-    ),
+    tickets: getUpdatedByIdsObject(state.tickets, [{id, qty: qty}]),
+    ticketCart: ticketCart,
   };
 
   if (!isValidDiscount(state.discount, updatedState)) {
@@ -721,6 +776,13 @@ const removeAllTicketsFromCartReducer: CaseReducer<ticketingState> = (
 ) => {
   const updatedState = {
     ...state,
+    tickets: getUpdatedByIdsObject(
+      state.tickets,
+      state.ticketCart.map((ticket) => ({
+        id: ticket.product_id,
+        qty: ticket.qty,
+      })),
+    ),
     ticketCart: [],
   };
 
@@ -746,11 +808,16 @@ const removeAllSubscriptionsFromCartReducer: CaseReducer<ticketingState> = (
   return updatedState;
 };
 
-const removeAllItemsFromCartReducer: CaseReducer<ticketingState> = (
-  state,
-) => {
+const removeAllItemsFromCartReducer: CaseReducer<ticketingState> = (state) => {
   const updatedState = {
     ...state,
+    tickets: getUpdatedByIdsObject(
+      state.tickets,
+      state.ticketCart.map((ticket) => ({
+        id: ticket.product_id,
+        qty: ticket.qty,
+      })),
+    ),
     ticketCart: [],
     subscriptionCart: [],
   };
@@ -838,7 +905,13 @@ const ticketingSlice = createSlice({
           ? action.payload.ticketRestrictions
           : [];
         state.tickets = action.payload.tickets
-          ? action.payload.tickets
+          ? getUpdatedByIdsObject(
+              action.payload.tickets,
+              state.ticketCart.map((ticket) => ({
+                id: ticket.product_id,
+                qty: -ticket.qty,
+              })),
+            )
           : {data: {byId: {}, allIds: []}};
       })
       .addCase(fetchTicketingData.rejected, (state) => {

--- a/server/src/controllers/eventInstanceController.ts
+++ b/server/src/controllers/eventInstanceController.ts
@@ -98,6 +98,10 @@ eventInstanceController.get('/tickets', async (_, res: Response) => {
           date: getDate(ticket.eventtime.toISOString(), ticket.eventdate),
           totalseats: ticket.totalseats,
           availableseats: ticket.availableseats,
+          remainingtickets: Math.min(
+            ticket.availableseats,
+            ticket.ticketrestrictions.reduce<number>((acc, res) => res.ticketlimit - res.ticketitems.length + acc, 0),
+          ),
           detail: ticket.detail,
         }};
       });


### PR DESCRIPTION
### Description
Primary Changes:

-  Update sold out indicators to reference the smaller of showing availability or ticket restriction availability. 
-  Update ticketing state so that a showing's available seats is updated correctly when a customer adds/removes tickets from their cart.  Currently, a customer can add more tickets to their cart than there are available for a showing by spreading the tickets across multiple ticket types, this update should eliminate that ability. 
-  Update the cart component so that it verifies item availability before checkout., and adjusts the cart to match availability. 

### Risks
It is possible that there is an error in the implementation logic and/or that the cart verification process is not how we want the issue to be handled. 

### Validation
Manual testing

### Issue
#640 

### Operating System
M1 Mac
