### PR TITLE
[WT-665] Update ticketing state to maintain accurate available seat count

### DIFF
--- a/client/src/components/Ticketing/event/TicketPicker.tsx
+++ b/client/src/components/Ticketing/event/TicketPicker.tsx
@@ -265,7 +265,7 @@ const TicketPicker = (props: TicketPickerProps): ReactElement => {
             throw response;
           }
           const data = await response.json();
-          setNumAvail(data.ticketlimit - data.ticketssold);
+          setNumAvail(Math.min(data.ticketlimit - data.ticketssold, selectedTicket.availableseats));
         } catch (error) {
           console.error(error);
         }
@@ -474,7 +474,7 @@ const TicketPicker = (props: TicketPickerProps): ReactElement => {
             disabled={
               !qty ||
               !selectedTicket ||
-              qty > selectedTicket.availableseats ||
+              qty > numAvail ||
               (selectedTicketType.name === 'Pay What You Can' &&
                 (payWhatPrice == null || payWhatPrice < 0))
             }

--- a/client/src/components/Ticketing/ticketingmanager/ticketingSlice.spec.ts
+++ b/client/src/components/Ticketing/ticketingmanager/ticketingSlice.spec.ts
@@ -214,6 +214,18 @@ describe('Ticketing slice', () => {
       expect(res)
         .toEqual({
           ...ticketingInitState,
+          tickets: {
+            data: {
+              ...ticketingInitState.tickets.data,
+              byId: {
+                ...ticketingInitState.tickets.data.byId,
+                [1]: {
+                  ...ticketingInitState.tickets.data.byId[1],
+                  availableseats: ticketingInitState.tickets.data.byId[1].availableseats - 2,
+                },
+              },
+            },
+          },
           ticketCart: [newCartItem],
         });
       init = res;
@@ -224,6 +236,18 @@ describe('Ticketing slice', () => {
       expect(ticketReducer(init, addTicketToCart(payload)))
         .toEqual({
           ...init,
+          tickets: {
+            data: {
+              ...init.tickets.data,
+              byId: {
+                ...init.tickets.data.byId,
+                [1]: {
+                  ...init.tickets.data.byId[1],
+                  availableseats: init.tickets.data.byId[1].availableseats - 1,
+                },
+              },
+            },
+          },
           ticketCart: [{...newCartItem, qty: 3}],
         });
     });
@@ -231,18 +255,63 @@ describe('Ticketing slice', () => {
     // ticket 1 currently in cart
     it('editItemQty: can set qty = available', () => {
       expect(ticketReducer(init, editItemQty({id: 1, tickettypeId: 1, qty: ticket1.availableseats})))
-        .toEqual({...init, ticketCart: [{...newCartItem, qty: ticket1.availableseats}]});
+        .toEqual({
+          ...init,
+          tickets: {
+            data: {
+              ...init.tickets.data,
+              byId: {
+                ...init.tickets.data.byId,
+                [1]: {
+                  ...init.tickets.data.byId[1],
+                  availableseats: 0,
+                },
+              },
+            },
+          },
+          ticketCart: [{...newCartItem, qty: ticket1.availableseats}],
+        });
     });
 
     it('editItemQty: can\'t set qty > available', () => {
       expect(ticketReducer(init, editItemQty({id: 1, tickettypeId: 1, qty: ticket1.availableseats + 1})))
-        .toEqual({...init, ticketCart: [{...newCartItem, qty: ticket1.availableseats}]});
+        .toEqual({
+          ...init,
+          tickets: {
+            data: {
+              ...init.tickets.data,
+              byId: {
+                ...init.tickets.data.byId,
+                [1]: {
+                  ...init.tickets.data.byId[1],
+                  availableseats: 0,
+                },
+              },
+            },
+          },
+          ticketCart: [{...newCartItem, qty: ticket1.availableseats}],
+        });
     });
 
     it('editItemQty: item exists in cart', () => {
       const res = ticketReducer(init, editItemQty({id: 1, tickettypeId: 1, qty: 4}));
       expect(res)
-        .toEqual({...init, ticketCart: [{...newCartItem, qty: 4}]});
+        .toEqual({
+          ...init,
+          tickets: {
+            data: {
+              ...init.tickets.data,
+              byId: {
+                ...init.tickets.data.byId,
+                [1]: {
+                  ...init.tickets.data.byId[1],
+                  availableseats: ticket1.availableseats-4,
+                },
+              },
+            },
+          },
+          ticketCart: [{...newCartItem, qty: 4}],
+        });
       init = res;
     });
 
@@ -253,7 +322,22 @@ describe('Ticketing slice', () => {
 
     it('editItemQty: can\'t set negative qty', () => {
       expect(ticketReducer(init, editItemQty({id: 1, tickettypeId: 1, qty: -1})))
-        .toEqual({...init, ticketCart: [{...newCartItem, qty: 0}]});
+        .toEqual({
+          ...init,
+          tickets: {
+            data: {
+              ...init.tickets.data,
+              byId: {
+                ...init.tickets.data.byId,
+                [1]: {
+                  ...init.tickets.data.byId[1],
+                  availableseats: ticket1.availableseats,
+                },
+              },
+            },
+          },
+          ticketCart: [{...newCartItem, qty: 0}],
+        });
     });
   });
 });

--- a/client/src/components/Ticketing/ticketingmanager/ticketingSlice.ts
+++ b/client/src/components/Ticketing/ticketingmanager/ticketingSlice.ts
@@ -517,24 +517,58 @@ const updateSubscriptionCartItem = (
  * @param eventInstanceId
  * @param ticketTypeId
  * @param ticket
+ * @param currentQty
  */
 const getTicketQuantityRange = (
   state: ticketingState,
   eventInstanceId: number,
   ticketTypeId: number,
   ticket: Ticket,
+  currentQty: number,
 ) => {
   const eventInstanceAvailableSeats = ticket.availableseats;
   const ticketRestriction = state.ticketrestrictions.find(
     byId(eventInstanceId, ticketTypeId),
   );
+  if (!ticketRestriction) {
+    return bound(0, 0);
+  }
   const ticketRestrictionAvailableSeats =
     ticketRestriction.ticketlimit - ticketRestriction.ticketssold;
   return bound(
     0,
-    Math.min(eventInstanceAvailableSeats, ticketRestrictionAvailableSeats),
+    Math.min(eventInstanceAvailableSeats, ticketRestrictionAvailableSeats)+currentQty,
   );
 };
+
+/**
+ * Updates available seats for the given id based on the qty provided
+ *
+ *
+ * @param currentTickets
+ * @param currentTickets.data
+ * @param toUpdate
+ * @param currentTickets.data.byId
+ * @param currentTickets.data.allIds
+ */
+const updateByIdObject = (
+  currentTickets: {data: {byId: {[key: string]: Ticket}; allIds: number[]}},
+  toUpdate: {id: number; qty: number}[],
+) => ({
+  data: {
+    ...currentTickets.data,
+    byId: toUpdate.reduce(
+      (acc, {id, qty}) => ({
+        ...acc,
+        [id]: {
+          ...acc[id],
+          availableseats: Math.max(acc[id].availableseats + qty, 0),
+        },
+      }),
+      {...currentTickets.data.byId},
+    ),
+  },
+});
 
 /**
  * addTicketReducer adds a ticketReducer to the payload and checks the id similar to qtyReducer
@@ -557,18 +591,28 @@ const addTicketReducer: CaseReducer<
   if (!tickets.data.allIds.includes(id)) return state;
 
   const ticket = tickets.data.byId[id];
-  const validRange = getTicketQuantityRange(state, id, tickettype.id, ticket);
 
   const ticketCartItem = state.ticketCart.find(byId(id, tickettype.id));
   let updatedState: ticketingState;
 
   if (ticketCartItem) {
+    const updatedQty = getTicketQuantityRange(
+      state,
+      id,
+      tickettype.id,
+      ticket,
+      ticketCartItem.qty,
+    )(qty + ticketCartItem.qty);
+
     updatedState = {
       ...state,
+      tickets: updateByIdObject(state.tickets, [
+        {id, qty: ticketCartItem.qty - updatedQty},
+      ]),
       ticketCart: updateTicketCartItem(state.ticketCart, {
         id,
         tickettypeId: tickettype.id,
-        qty: validRange(qty + ticketCartItem.qty),
+        qty: updatedQty,
         payWhatPrice,
       }),
     };
@@ -582,6 +626,9 @@ const addTicketReducer: CaseReducer<
     updatedState = newCartItem
       ? {
           ...state,
+          tickets: updateByIdObject(state.tickets, [
+            {id, qty: -newCartItem.qty},
+          ]),
           ticketCart: [...state.ticketCart, newCartItem],
         }
       : {...state};
@@ -628,14 +675,18 @@ const editQtyReducer: CaseReducer<
   if (!state.tickets.data.allIds.includes(id)) return state;
 
   const ticket = state.tickets.data.byId[id];
-  const validRange = getTicketQuantityRange(state, id, tickettypeId, ticket);
+  const ticketItem = state.ticketCart.find(byId(id, tickettypeId));
+  const updatedQty = getTicketQuantityRange(state, id, tickettypeId, ticket, ticketItem?.qty ?? 0)(qty);
 
   const updatedState = {
     ...state,
+    tickets: ticketItem
+      ? updateByIdObject(state.tickets, [{id, qty: ticketItem.qty - updatedQty}])
+      : state.tickets,
     ticketCart: updateTicketCartItem(state.ticketCart, {
       id,
       tickettypeId,
-      qty: validRange(qty),
+      qty: updatedQty,
     }),
   };
 
@@ -682,11 +733,17 @@ const removeTicketFromCartReducer: CaseReducer<
   PayloadAction<{id: number; tickettypeId: number}>
 > = (state, action) => {
   const {id, tickettypeId} = action.payload;
+  const {qty, ticketCart} = state.ticketCart.reduce(
+    (acc, ticket) =>
+      ticket.product_id === id && ticket.typeID === tickettypeId
+        ? {...acc, qty: ticket.qty}
+        : {...acc, ticketCart: [...acc.ticketCart, ticket]},
+    {qty: 0, ticketCart: []},
+  );
   const updatedState = {
     ...state,
-    ticketCart: state.ticketCart.filter(
-      (item) => item.product_id !== id || item.typeID !== tickettypeId,
-    ),
+    tickets: updateByIdObject(state.tickets, [{id, qty: qty}]),
+    ticketCart: ticketCart,
   };
 
   if (!isValidDiscount(state.discount, updatedState)) {
@@ -721,6 +778,13 @@ const removeAllTicketsFromCartReducer: CaseReducer<ticketingState> = (
 ) => {
   const updatedState = {
     ...state,
+    tickets: updateByIdObject(
+      state.tickets,
+      state.ticketCart.map((ticket) => ({
+        id: ticket.product_id,
+        qty: ticket.qty,
+      })),
+    ),
     ticketCart: [],
   };
 
@@ -746,11 +810,16 @@ const removeAllSubscriptionsFromCartReducer: CaseReducer<ticketingState> = (
   return updatedState;
 };
 
-const removeAllItemsFromCartReducer: CaseReducer<ticketingState> = (
-  state,
-) => {
+const removeAllItemsFromCartReducer: CaseReducer<ticketingState> = (state) => {
   const updatedState = {
     ...state,
+    tickets: updateByIdObject(
+      state.tickets,
+      state.ticketCart.map((ticket) => ({
+        id: ticket.product_id,
+        qty: ticket.qty,
+      })),
+    ),
     ticketCart: [],
     subscriptionCart: [],
   };
@@ -838,7 +907,13 @@ const ticketingSlice = createSlice({
           ? action.payload.ticketRestrictions
           : [];
         state.tickets = action.payload.tickets
-          ? action.payload.tickets
+          ? updateByIdObject(
+              action.payload.tickets,
+              state.ticketCart.map((ticket) => ({
+                id: ticket.product_id,
+                qty: -ticket.qty,
+              })),
+            )
           : {data: {byId: {}, allIds: []}};
       })
       .addCase(fetchTicketingData.rejected, (state) => {


### PR DESCRIPTION
### Description
Update ticketing state to prevent customers from adding more tickets to their cart than there are available seats for a showing by selecting different ticket types.

Note: When merged with the PR for issue 640 if a customer has added the maximum number of tickets available for a showing to their cart the showing wont show up as sold out, but rather the customer will just not be able to add additional tickets.

### Risks
Implementation logic could be incorrect. 

### Validation
Manual testing

### Issue
#665 

### Operating System
M1 Mac