### PR TITLE
Make order and refund state database fields optional

### DIFF
--- a/server/prisma/migrations/20240507011154_make_status_fields_optional/migration.sql
+++ b/server/prisma/migrations/20240507011154_make_status_fields_optional/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "orders" ALTER COLUMN "order_status" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "refunds" ALTER COLUMN "refund_status" DROP NOT NULL;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -210,7 +210,7 @@ model orders {
   feetotal          Decimal            @default(0) @db.Money
   contacts          contacts?          @relation(fields: [contactid_fk], references: [contactid], onDelete: Restrict, onUpdate: Cascade, map: "orders_contactid_fkey")
   order_source      purchase_source?
-  order_status      state
+  order_status      state?
   discounts         discounts?         @relation(fields: [discountid_fk], references: [discountid], onDelete: Restrict, onUpdate: Cascade, map: "orders_discountid_fkey")
   donation          donations?
   refunds           refunds[]
@@ -222,7 +222,7 @@ model refunds {
   id            Int           @id @default(autoincrement())
   orderid_fk    Int
   refund_intent String        @unique @db.VarChar(255)
-  refund_status state
+  refund_status state?
   order         orders        @relation(fields: [orderid_fk], references: [orderid], onDelete: Restrict, onUpdate: Cascade)
   refunditems   refunditems[]
 }


### PR DESCRIPTION
### Description
This should hopefully fix an error applying latest database migration in dev ([logs](https://console.cloud.google.com/logs/query;cursorTimestamp=2024-05-01T17:55:08.388472Z;endTime=2024-05-02T05:44:00.000Z;pinnedLogId=2024-05-06T23:24:29.184246Z%2F663966ad0002cfb6167f0bee;query=resource.type%20%3D%20%22cloud_run_revision%22%0Aresource.labels.service_name%20%3D%20%22wtix-server-dev%22%0Aresource.labels.location%20%3D%20%22us-west1%22%0A%20severity%3E%3DDEFAULT%0Atimestamp%3D%222024-05-01T17:55:00.632914Z%22%0AinsertId%3D%22663281f40009a852c065f35c%22;startTime=2024-05-01T13:00:00.000Z?project=wondertix-app))

### Risks
If there is logic that expects the order or refund state to not be null and isn't validating that it isn't first, this could cause some NPEs or otherwise blow something up 

### Validation
local deployment with seeded data comes up healthy with all migrations successfully applied

### Operating System
win10
